### PR TITLE
[08 Sizes] Copy HYPHEN-MINUS into U+00ad SOFT HYPHEN

### DIFF
--- a/SFD/EBGaramond08-Italic.sfdir/_T_h.glyph
+++ b/SFD/EBGaramond08-Italic.sfdir/_T_h.glyph
@@ -49,5 +49,5 @@ SplineSet
  128 490 189 545 230 545 c 2
 EndSplineSet
 Ligature2: "'dlig' optionale Ligaturen lookup 50 subtable" T h
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar

--- a/SFD/EBGaramond08-Italic.sfdir/a_s.glyph
+++ b/SFD/EBGaramond08-Italic.sfdir/a_s.glyph
@@ -41,5 +41,5 @@ SplineSet
 EndSplineSet
 Ligature2: "Ligature Substitution lookup 56 subtable" a s
 Ligature2: "Ligature Substitution lookup 52 subtable" a s
-LCarets2: 1 498 
+LCarets2: 1 498
 EndChar

--- a/SFD/EBGaramond08-Italic.sfdir/ae.glyph
+++ b/SFD/EBGaramond08-Italic.sfdir/ae.glyph
@@ -35,5 +35,5 @@ SplineSet
 EndSplineSet
 Substitution2: "Smallcaps subtable" ae.sc
 Ligature2: "LATliga subtable" a e
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar

--- a/SFD/EBGaramond08-Italic.sfdir/c_t.glyph
+++ b/SFD/EBGaramond08-Italic.sfdir/c_t.glyph
@@ -49,5 +49,5 @@ SplineSet
  637 635 575.516601562 606.126953125 567 565 c 2
 EndSplineSet
 Ligature2: "'hlig' Historic Ligatures lookup 48 subtable" c t
-LCarets2: 1 305 
+LCarets2: 1 305
 EndChar

--- a/SFD/EBGaramond08-Italic.sfdir/f_a.glyph
+++ b/SFD/EBGaramond08-Italic.sfdir/f_a.glyph
@@ -50,6 +50,6 @@ SplineSet
  608 326 592 347 569 347 c 0
  521 347 357 161 357 86 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 Ligature2: "'dlig' optionale Ligaturen lookup 50 subtable" f a
 EndChar

--- a/SFD/EBGaramond08-Italic.sfdir/f_e.glyph
+++ b/SFD/EBGaramond08-Italic.sfdir/f_e.glyph
@@ -47,6 +47,6 @@ SplineSet
  549 384 530 390 513 390 c 0
  482 390 401 295 401 244 c 0
 EndSplineSet
-LCarets2: 1 278 
+LCarets2: 1 278
 Ligature2: "'dlig' optionale Ligaturen lookup 50 subtable" f e
 EndChar

--- a/SFD/EBGaramond08-Italic.sfdir/f_f.glyph
+++ b/SFD/EBGaramond08-Italic.sfdir/f_f.glyph
@@ -56,5 +56,5 @@ Substitution2: "Single Substitution lookup 64 subtable" f_f.short
 Substitution2: "Single Substitution lookup 63 subtable" f_f.short
 Ligature2: "liga_standard subtable" f.DEU f.DEU
 Ligature2: "liga_standard subtable" f f
-LCarets2: 1 199 
+LCarets2: 1 199
 EndChar

--- a/SFD/EBGaramond08-Italic.sfdir/f_o.glyph
+++ b/SFD/EBGaramond08-Italic.sfdir/f_o.glyph
@@ -41,6 +41,6 @@ SplineSet
  302 218 329.49609375 300.084960938 384.49609375 359.084960938 c 0
  398.49609375 374.084960938 394.040039062 381.157226562 382 381 c 2
 EndSplineSet
-LCarets2: 1 282 
+LCarets2: 1 282
 Ligature2: "'dlig' optionale Ligaturen lookup 50 subtable" f o
 EndChar

--- a/SFD/EBGaramond08-Italic.sfdir/f_u.glyph
+++ b/SFD/EBGaramond08-Italic.sfdir/f_u.glyph
@@ -48,6 +48,6 @@ SplineSet
  230 437 225.26953125 425.629882812 241 426 c 2
  411 430 l 2
 EndSplineSet
-LCarets2: 1 279 
+LCarets2: 1 279
 Ligature2: "'dlig' optionale Ligaturen lookup 50 subtable" f u
 EndChar

--- a/SFD/EBGaramond08-Italic.sfdir/font.props
+++ b/SFD/EBGaramond08-Italic.sfdir/font.props
@@ -1,4 +1,4 @@
-SplineFontDB: 3.0
+SplineFontDB: 3.2
 FontName: EBGaramond08-Italic
 FullName: EB Garamond 08 Italic
 FamilyName: EB Garamond 08
@@ -10,17 +10,18 @@ UnderlinePosition: -66
 UnderlineWidth: 70
 Ascent: 726
 Descent: 274
+InvalidEm: 0
 sfntRevision: 0x00010000
 LayerCount: 2
-Layer: 0 0 "Back"  1
-Layer: 1 0 "Zeichenebene"  0
+Layer: 0 0 "Back" 1
+Layer: 1 0 "Zeichenebene" 0
 XUID: [1021 660 827469224 11547081]
 FSType: 0
 OS2Version: 4
 OS2_WeightWidthSlopeOnly: 0
 OS2_UseTypoMetrics: 1
 CreationTime: 1339342330
-ModificationTime: 1373642953
+ModificationTime: 1614047757
 PfmFamily: 17
 TTFWeight: 400
 TTFWidth: 5
@@ -54,80 +55,80 @@ OS2FamilyClass: 258
 OS2Vendor: 'PfEd'
 OS2CodePages: 20000111.41000000
 OS2UnicodeRanges: 800000a7.5000004a.00000000.00000000
-Lookup: 1 0 0 "loclDEU"  {"loclDEU subtable"  } ['locl' ('latn' <'DEU ' > ) ]
-Lookup: 1 0 0 "loclTRK"  {"loclTRK subtable"  } ['locl' ('latn' <'TRK ' 'AZE ' 'CRT ' > ) ]
-Lookup: 1 0 0 "loclCAT"  {"loclCAT subtable"  } ['locl' ('latn' <'CAT ' > ) ]
-Lookup: 1 0 0 "loclSRB"  {"loclSRB subtable"  } ['locl' ('cyrl' <'SRB ' 'MKD ' > ) ]
-Lookup: 1 0 0 "loclLAT"  {"loclLAT subtable"  } ['locl' ('latn' <'LAT ' > ) ]
-Lookup: 4 0 0 "LATliga"  {"LATliga subtable"  } []
-Lookup: 1 0 0 "'case' Case-Sensitive Forms lookup 6"  {"'case' Case-Sensitive Forms lookup 6 subtable"  } ['case' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
-Lookup: 6 0 0 "CCMP_contextual"  {"CCMP_contextual contextual 0"  "CCMP_contextual contextual 1"  } ['ccmp' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
-Lookup: 1 0 0 "Single Substitution lookup 8"  {"Single Substitution lookup 8 subtable"  } []
-Lookup: 1 0 0 "Single Substitution lookup 9"  {"Single Substitution lookup 9 subtable"  } []
-Lookup: 6 0 0 "CCMP_stacking1"  {"CCMP_stacking1 subtable"  } ['ccmp' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
-Lookup: 1 0 0 "Single Substitution lookup 11"  {"Single Substitution lookup 11 subtable"  } []
-Lookup: 6 0 0 "CCMP_stacking2"  {"CCMP_stacking2 subtable"  } ['ccmp' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
-Lookup: 1 0 0 "Single Substitution lookup 13"  {"Single Substitution lookup 13 subtable"  } []
-Lookup: 6 0 0 "CCMP_stackgrk1"  {"CCMP_stackgrk1 contextual 0"  "CCMP_stackgrk1 contextual 1"  "CCMP_stackgrk1 contextual 2"  "CCMP_stackgrk1 contextual 3"  } ['ccmp' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
-Lookup: 1 0 0 "Single Substitution lookup 15"  {"Single Substitution lookup 15 subtable"  } []
-Lookup: 1 0 0 "Single Substitution lookup 16"  {"Single Substitution lookup 16 subtable"  } []
-Lookup: 1 0 0 "Single Substitution lookup 17"  {"Single Substitution lookup 17 subtable"  } []
-Lookup: 1 0 0 "Single Substitution lookup 18"  {"Single Substitution lookup 18 subtable"  } []
-Lookup: 6 0 0 "CCMP_stackgrk2"  {"CCMP_stackgrk2 subtable"  } ['ccmp' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
-Lookup: 1 0 0 "Single Substitution lookup 20"  {"Single Substitution lookup 20 subtable"  } []
-Lookup: 2 0 0 "CCMP_Precomp"  {"CCMP_Precomp subtable"  } ['ss20' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
-Lookup: 1 0 0 "cyrillic_DLLj"  {"cyrillic_DLLj subtable"  } ['ss01' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
-Lookup: 6 0 0 "historic_u"  {"historic_u contextual 0"  "historic_u contextual 1"  "historic_u contextual 2"  "historic_u contextual 3"  } ['ss02' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
-Lookup: 1 0 0 "Single Substitution lookup 24"  {"Single Substitution lookup 24 subtable"  } []
-Lookup: 1 0 0 "Single Substitution lookup 25"  {"Single Substitution lookup 25 subtable"  } []
-Lookup: 1 0 0 "Single Substitution lookup 26"  {"Single Substitution lookup 26 subtable"  } []
-Lookup: 1 0 0 "ss03"  {"ss03 subtable"  } ['ss03' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
-Lookup: 6 0 0 "longs_replacement"  {"longs_replacement subtable"  } ['cv01' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
-Lookup: 1 0 0 "Single Substitution lookup 29"  {"Single Substitution lookup 29 subtable"  } []
-Lookup: 1 0 0 "at_alternates"  {"at_alternates subtable"  } ['cv02' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
-Lookup: 1 0 0 "historic_j"  {"historic_j subtable"  } ['cv03' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
-Lookup: 1 0 0 "ampersand_alt"  {"ampersand_alt subtable"  } ['cv04' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
-Lookup: 3 0 0 "v_alternates"  {"v_alternates subtable"  } ['cv05' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
-Lookup: 1 0 0 "subs"  {"subs subtable" ("inferior" ) } ['dnom' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) 'subs' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
-Lookup: 1 0 0 "ordn"  {"ordn subtable"  } ['numr' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) 'ordn' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
-Lookup: 1 0 0 "sinf"  {"sinf subtable"  } ['sinf' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
-Lookup: 1 0 0 "sups"  {"sups subtable" ("superior" ) } ['sups' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
-Lookup: 1 0 0 "frac_slash"  {"frac_slash subtable"  } ['frac' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
-Lookup: 6 0 0 "frac"  {"frac contextual 0"  "frac contextual 1"  } ['frac' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
-Lookup: 1 0 0 "Single Substitution lookup 40"  {"Single Substitution lookup 40 subtable"  } []
-Lookup: 1 0 0 "Single Substitution lookup 41"  {"Single Substitution lookup 41 subtable"  } []
-Lookup: 1 0 0 "'lnum' Lining Figures lookup 42"  {"'lnum' Lining Figures lookup 42 subtable"  } ['lnum' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
-Lookup: 1 0 0 "'onum' Minuskelziffern lookup 43"  {"'onum' Minuskelziffern lookup 43 subtable" ("oldstyle" ) } ['onum' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
-Lookup: 1 0 0 "'tnum' Tabular Numbers lookup 44"  {"'tnum' Tabular Numbers lookup 44 subtable"  } ['tnum' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
-Lookup: 1 0 0 "'pnum' Proportionalziffern lookup 45"  {"'pnum' Proportionalziffern lookup 45 subtable"  } ['pnum' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
-Lookup: 1 0 0 "Smallcaps"  {"Smallcaps subtable"  } ['smcp' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
-Lookup: 1 0 0 "c2sc"  {"c2sc subtable"  } ['c2sc' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
-Lookup: 4 0 0 "'hlig' Historic Ligatures lookup 48"  {"'hlig' Historic Ligatures lookup 48 subtable"  } ['hlig' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
-Lookup: 4 0 1 "liga_standard"  {"liga_standard subtable"  } ['liga' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
-Lookup: 4 0 0 "'dlig' optionale Ligaturen lookup 50"  {"'dlig' optionale Ligaturen lookup 50 subtable"  } ['dlig' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
-Lookup: 6 0 0 "liga_final_s1"  {"liga_final_s1 contextual 0"  "liga_final_s1 contextual 1"  "liga_final_s1 contextual 2"  } ['clig' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
-Lookup: 4 0 0 "Ligature Substitution lookup 52"  {"Ligature Substitution lookup 52 subtable"  } []
-Lookup: 4 0 0 "Ligature Substitution lookup 53"  {"Ligature Substitution lookup 53 subtable"  } []
-Lookup: 4 0 0 "Ligature Substitution lookup 54"  {"Ligature Substitution lookup 54 subtable"  } []
-Lookup: 6 0 0 "liga_final_s2"  {"liga_final_s2 contextual 0"  "liga_final_s2 contextual 1"  "liga_final_s2 contextual 2"  "liga_final_s2 contextual 3"  } ['clig' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
-Lookup: 4 0 0 "Ligature Substitution lookup 56"  {"Ligature Substitution lookup 56 subtable"  } []
-Lookup: 4 0 0 "Ligature Substitution lookup 57"  {"Ligature Substitution lookup 57 subtable"  } []
-Lookup: 4 0 0 "Ligature Substitution lookup 58"  {"Ligature Substitution lookup 58 subtable"  } []
-Lookup: 6 0 0 "Q_longtail"  {"Q_longtail contextual 0"  "Q_longtail contextual 1"  } ['calt' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
-Lookup: 1 0 0 "Single Substitution lookup 60"  {"Single Substitution lookup 60 subtable"  } []
-Lookup: 1 0 0 "Single Substitution lookup 61"  {"Single Substitution lookup 61 subtable"  } []
-Lookup: 6 0 0 "f_short"  {"f_short contextual 0"  "f_short contextual 1"  } ['calt' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
-Lookup: 1 0 0 "Single Substitution lookup 63"  {"Single Substitution lookup 63 subtable"  } []
-Lookup: 1 0 0 "Single Substitution lookup 64"  {"Single Substitution lookup 64 subtable"  } []
-Lookup: 6 0 0 "caltLAT"  {"caltLAT subtable"  } ['calt' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
-Lookup: 1 0 0 "Single Substitution lookup 66"  {"Single Substitution lookup 66 subtable"  } []
-Lookup: 1 0 0 "Swash"  {"Swash subtable" ("swash" ) } ['swsh' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
-Lookup: 258 0 0 "kern"  {"kern subtable"  } ['kern' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
-Lookup: 260 0 0 "mark"  {"mark anchor 0"  "mark anchor 1"  "mark anchor 2"  } ['mark' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
-Lookup: 262 0 0 "mkmk"  {"mkmk subtable"  } ['mkmk' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
+Lookup: 1 0 0 "loclDEU" { "loclDEU subtable"  } ['locl' ('latn' <'DEU ' > ) ]
+Lookup: 1 0 0 "loclTRK" { "loclTRK subtable"  } ['locl' ('latn' <'TRK ' 'AZE ' 'CRT ' > ) ]
+Lookup: 1 0 0 "loclCAT" { "loclCAT subtable"  } ['locl' ('latn' <'CAT ' > ) ]
+Lookup: 1 0 0 "loclSRB" { "loclSRB subtable"  } ['locl' ('cyrl' <'SRB ' 'MKD ' > ) ]
+Lookup: 1 0 0 "loclLAT" { "loclLAT subtable"  } ['locl' ('latn' <'LAT ' > ) ]
+Lookup: 4 0 0 "LATliga" { "LATliga subtable"  } []
+Lookup: 1 0 0 "'case' Case-Sensitive Forms lookup 6" { "'case' Case-Sensitive Forms lookup 6 subtable"  } ['case' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
+Lookup: 6 0 0 "CCMP_contextual" { "CCMP_contextual contextual 0"  "CCMP_contextual contextual 1"  } ['ccmp' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
+Lookup: 1 0 0 "Single Substitution lookup 8" { "Single Substitution lookup 8 subtable"  } []
+Lookup: 1 0 0 "Single Substitution lookup 9" { "Single Substitution lookup 9 subtable"  } []
+Lookup: 6 0 0 "CCMP_stacking1" { "CCMP_stacking1 subtable"  } ['ccmp' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
+Lookup: 1 0 0 "Single Substitution lookup 11" { "Single Substitution lookup 11 subtable"  } []
+Lookup: 6 0 0 "CCMP_stacking2" { "CCMP_stacking2 subtable"  } ['ccmp' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
+Lookup: 1 0 0 "Single Substitution lookup 13" { "Single Substitution lookup 13 subtable"  } []
+Lookup: 6 0 0 "CCMP_stackgrk1" { "CCMP_stackgrk1 contextual 0"  "CCMP_stackgrk1 contextual 1"  "CCMP_stackgrk1 contextual 2"  "CCMP_stackgrk1 contextual 3"  } ['ccmp' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
+Lookup: 1 0 0 "Single Substitution lookup 15" { "Single Substitution lookup 15 subtable"  } []
+Lookup: 1 0 0 "Single Substitution lookup 16" { "Single Substitution lookup 16 subtable"  } []
+Lookup: 1 0 0 "Single Substitution lookup 17" { "Single Substitution lookup 17 subtable"  } []
+Lookup: 1 0 0 "Single Substitution lookup 18" { "Single Substitution lookup 18 subtable"  } []
+Lookup: 6 0 0 "CCMP_stackgrk2" { "CCMP_stackgrk2 subtable"  } ['ccmp' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
+Lookup: 1 0 0 "Single Substitution lookup 20" { "Single Substitution lookup 20 subtable"  } []
+Lookup: 2 0 0 "CCMP_Precomp" { "CCMP_Precomp subtable"  } ['ss20' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
+Lookup: 1 0 0 "cyrillic_DLLj" { "cyrillic_DLLj subtable"  } ['ss01' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
+Lookup: 6 0 0 "historic_u" { "historic_u contextual 0"  "historic_u contextual 1"  "historic_u contextual 2"  "historic_u contextual 3"  } ['ss02' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
+Lookup: 1 0 0 "Single Substitution lookup 24" { "Single Substitution lookup 24 subtable"  } []
+Lookup: 1 0 0 "Single Substitution lookup 25" { "Single Substitution lookup 25 subtable"  } []
+Lookup: 1 0 0 "Single Substitution lookup 26" { "Single Substitution lookup 26 subtable"  } []
+Lookup: 1 0 0 "ss03" { "ss03 subtable"  } ['ss03' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
+Lookup: 6 0 0 "longs_replacement" { "longs_replacement subtable"  } ['cv01' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
+Lookup: 1 0 0 "Single Substitution lookup 29" { "Single Substitution lookup 29 subtable"  } []
+Lookup: 1 0 0 "at_alternates" { "at_alternates subtable"  } ['cv02' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
+Lookup: 1 0 0 "historic_j" { "historic_j subtable"  } ['cv03' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
+Lookup: 1 0 0 "ampersand_alt" { "ampersand_alt subtable"  } ['cv04' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
+Lookup: 3 0 0 "v_alternates" { "v_alternates subtable"  } ['cv05' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
+Lookup: 1 0 0 "subs" { "subs subtable" ("inferior") } ['dnom' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) 'subs' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
+Lookup: 1 0 0 "ordn" { "ordn subtable"  } ['numr' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) 'ordn' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
+Lookup: 1 0 0 "sinf" { "sinf subtable"  } ['sinf' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
+Lookup: 1 0 0 "sups" { "sups subtable" ("superior") } ['sups' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
+Lookup: 1 0 0 "frac_slash" { "frac_slash subtable"  } ['frac' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
+Lookup: 6 0 0 "frac" { "frac contextual 0"  "frac contextual 1"  } ['frac' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
+Lookup: 1 0 0 "Single Substitution lookup 40" { "Single Substitution lookup 40 subtable"  } []
+Lookup: 1 0 0 "Single Substitution lookup 41" { "Single Substitution lookup 41 subtable"  } []
+Lookup: 1 0 0 "'lnum' Lining Figures lookup 42" { "'lnum' Lining Figures lookup 42 subtable"  } ['lnum' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
+Lookup: 1 0 0 "'onum' Minuskelziffern lookup 43" { "'onum' Minuskelziffern lookup 43 subtable" ("oldstyle") } ['onum' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
+Lookup: 1 0 0 "'tnum' Tabular Numbers lookup 44" { "'tnum' Tabular Numbers lookup 44 subtable"  } ['tnum' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
+Lookup: 1 0 0 "'pnum' Proportionalziffern lookup 45" { "'pnum' Proportionalziffern lookup 45 subtable"  } ['pnum' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
+Lookup: 1 0 0 "Smallcaps" { "Smallcaps subtable"  } ['smcp' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
+Lookup: 1 0 0 "c2sc" { "c2sc subtable"  } ['c2sc' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
+Lookup: 4 0 0 "'hlig' Historic Ligatures lookup 48" { "'hlig' Historic Ligatures lookup 48 subtable"  } ['hlig' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
+Lookup: 4 0 1 "liga_standard" { "liga_standard subtable"  } ['liga' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
+Lookup: 4 0 0 "'dlig' optionale Ligaturen lookup 50" { "'dlig' optionale Ligaturen lookup 50 subtable"  } ['dlig' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
+Lookup: 6 0 0 "liga_final_s1" { "liga_final_s1 contextual 0"  "liga_final_s1 contextual 1"  "liga_final_s1 contextual 2"  } ['clig' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
+Lookup: 4 0 0 "Ligature Substitution lookup 52" { "Ligature Substitution lookup 52 subtable"  } []
+Lookup: 4 0 0 "Ligature Substitution lookup 53" { "Ligature Substitution lookup 53 subtable"  } []
+Lookup: 4 0 0 "Ligature Substitution lookup 54" { "Ligature Substitution lookup 54 subtable"  } []
+Lookup: 6 0 0 "liga_final_s2" { "liga_final_s2 contextual 0"  "liga_final_s2 contextual 1"  "liga_final_s2 contextual 2"  "liga_final_s2 contextual 3"  } ['clig' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
+Lookup: 4 0 0 "Ligature Substitution lookup 56" { "Ligature Substitution lookup 56 subtable"  } []
+Lookup: 4 0 0 "Ligature Substitution lookup 57" { "Ligature Substitution lookup 57 subtable"  } []
+Lookup: 4 0 0 "Ligature Substitution lookup 58" { "Ligature Substitution lookup 58 subtable"  } []
+Lookup: 6 0 0 "Q_longtail" { "Q_longtail contextual 0"  "Q_longtail contextual 1"  } ['calt' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
+Lookup: 1 0 0 "Single Substitution lookup 60" { "Single Substitution lookup 60 subtable"  } []
+Lookup: 1 0 0 "Single Substitution lookup 61" { "Single Substitution lookup 61 subtable"  } []
+Lookup: 6 0 0 "f_short" { "f_short contextual 0"  "f_short contextual 1"  } ['calt' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
+Lookup: 1 0 0 "Single Substitution lookup 63" { "Single Substitution lookup 63 subtable"  } []
+Lookup: 1 0 0 "Single Substitution lookup 64" { "Single Substitution lookup 64 subtable"  } []
+Lookup: 6 0 0 "caltLAT" { "caltLAT subtable"  } ['calt' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
+Lookup: 1 0 0 "Single Substitution lookup 66" { "Single Substitution lookup 66 subtable"  } []
+Lookup: 1 0 0 "Swash" { "Swash subtable" ("swash") } ['swsh' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
+Lookup: 258 0 0 "kern" { "kern subtable"  } ['kern' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
+Lookup: 260 0 0 "mark" { "mark anchor 0"  "mark anchor 1"  "mark anchor 2"  } ['mark' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
+Lookup: 262 0 0 "mkmk" { "mkmk subtable"  } ['mkmk' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' 'BGR ' > 'DFLT' <'dflt' > ) ]
 MarkAttachClasses: 1
 DEI: 91125
-KernClass2: 13 10 "kern subtable" 
+KernClass2: 13 10 "kern subtable"
  1 A
  9 A.sc a.sc
  86 E Eacute Ebreve Ecaron Ecircumflex Edieresis Edotaccent Egrave Emacron Eogonek uni1EBC
@@ -150,213 +151,213 @@ KernClass2: 13 10 "kern subtable"
  1 t
  7 v w x y
  0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -50 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -75 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -15 {} -15 {} 0 {} -10 {} -20 {} 0 {} 0 {} 0 {} 0 {} 0 {} -20 {} -20 {} -30 {} -10 {} -20 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -20 {} 0 {} 0 {} 0 {} 0 {} 0 {} -10 {} -10 {} 0 {} -20 {} -20 {} 0 {} -95 {} 0 {} 0 {} 0 {} -10 {} -10 {} 0 {} 0 {} 0 {} 0 {} -130 {} 0 {} 0 {} 0 {} -120 {} -120 {} -100 {} -80 {} -90 {} 0 {} -230 {} 0 {} 0 {} 0 {} -180 {} -160 {} 0 {} -130 {} 0 {} 0 {} 0 {} -95 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -35 {} 0 {} 0 {} 0 {} 0 {} 0 {} -90 {} 0 {} 0 {} 0 {} -20 {} 0 {} 0 {} 0 {} 0 {}
-ChainSub2: coverage "caltLAT subtable"  0 0 0 1
+ChainSub2: coverage "caltLAT subtable" 0 0 0 1
  1 1 0
   Coverage: 11 u.LAT v.LAT
   BCoverage: 1504 A B C D E F G H I J K L M N O P Q R S T U V W X Y Z Agrave Aacute Acircumflex Atilde Adieresis Aring AE Ccedilla Egrave Eacute Ecircumflex Edieresis Igrave Iacute Icircumflex Idieresis Eth Ntilde Ograve Oacute Ocircumflex Otilde Odieresis Oslash Ugrave Uacute Ucircumflex Udieresis Yacute Thorn Amacron Abreve Aogonek Cacute Ccircumflex Cdotaccent Ccaron Dcaron Dcroat Emacron Ebreve Edotaccent Eogonek Ecaron Gcircumflex Gbreve Gdotaccent uni0122 Hcircumflex Hbar Itilde Imacron Ibreve Iogonek Idotaccent IJ Jcircumflex uni0136 Lacute uni013B Lcaron Ldot Lslash Nacute uni0145 Ncaron Eng Omacron Obreve Ohungarumlaut OE Racute uni0156 Rcaron Sacute Scircumflex Scedilla Scaron uni0162 Tcaron Tbar Utilde Umacron Ubreve Uring Uhungarumlaut Uogonek Wcircumflex Ycircumflex Ydieresis Zacute Zdotaccent Zcaron L.CAT U.LAT A.sw B.sw C.sw D.sw E.sw F.sw G.sw H.sw I.sw J.sw K.sw L.sw M.sw N.sw O.sw P.sw Q.sw R.sw S.sw T.sw U.sw V.sw W.sw X.sw Y.sw Z.sw a b c d e f g h i j k l m n o p q r s t u v w x y z longs germandbls adieresis edieresis odieresis udieresis idieresis aacute eacute iacute oacute uacute agrave egrave igrave ograve ugrave atilde etilde otilde utilde oe f.DEU f.short i.TRK l.CAT u.LAT v.LATmedi longs.short v.init w.init v.alt w.alt f_f unifb01 unifb02 unifb03 unifb04 unifb05 unifb06 longs_longs_l longs_longs_i longs_i longs_longs longs_l T_h c_h c_k longs_s s_s c_t f_f.short t_t t_z f_h f_k f_b f_t f_j longs_j longs_b longs_h longs_k longs_longs.short U.LAT u.LAT u.LATmedi v.LATmedi
  1
-  SeqLookup: 0 "Single Substitution lookup 66" 
+  SeqLookup: 0 "Single Substitution lookup 66"
 EndFPST
-ChainSub2: coverage "f_short contextual 1"  0 0 0 1
+ChainSub2: coverage "f_short contextual 1" 0 0 0 1
  1 0 2
   Coverage: 29 f f_f f.DEU longs longs_longs
   FCoverage: 7 uni200C
   FCoverage: 405 b f h i j k l adieresis edieresis idieresis odieresis udieresis dotlessi thorn eth longs bracketright braceright question exclam parenright i i.TRK f.DEU f_f uniFB01 uniFB02 uniFB03 uniFB04 uniFB05 uniFB06 f_f.short f.short f_h f_k f_b f_t f_j longs_j longs_b longs_h longs_k longs.short longs_longs.short f_f_h f_f_k f_f_b f_f_t f_f_j longs_longs_j longs_longs_b longs_longs_h longs_longs_k longs_longs_t
  1
-  SeqLookup: 0 "Single Substitution lookup 64" 
+  SeqLookup: 0 "Single Substitution lookup 64"
 EndFPST
-ChainSub2: coverage "f_short contextual 0"  0 0 0 1
+ChainSub2: coverage "f_short contextual 0" 0 0 0 1
  1 0 1
   Coverage: 29 f f_f f.DEU longs longs_longs
   FCoverage: 1713 A B C D E F G H I J K L M N O P Q R S T U V W X Y Z Agrave Aacute Acircumflex Atilde Adieresis Aring AE Ccedilla Egrave Eacute Ecircumflex Edieresis Igrave Iacute Icircumflex Idieresis Eth Ntilde Ograve Oacute Ocircumflex Otilde Odieresis Oslash Ugrave Uacute Ucircumflex Udieresis Yacute Thorn Amacron Abreve Aogonek Cacute Ccircumflex Cdotaccent Ccaron Dcaron Dcroat Emacron Ebreve Edotaccent Eogonek Ecaron Gcircumflex Gbreve Gdotaccent uni0122 Hcircumflex Hbar Itilde Imacron Ibreve Iogonek Idotaccent IJ Jcircumflex uni0136 Lacute uni013B Lcaron Ldot Lslash Nacute uni0145 Ncaron Eng Omacron Obreve Ohungarumlaut OE Racute uni0156 Rcaron Sacute Scircumflex Scedilla Scaron uni0162 Tcaron Tbar Utilde Umacron Ubreve Uring Uhungarumlaut Uogonek Wcircumflex Ycircumflex Ydieresis Zacute Zdotaccent Zcaron L.CAT U.LAT A.sw B.sw C.sw D.sw E.sw F.sw G.sw H.sw I.sw J.sw K.sw L.sw M.sw N.sw O.sw P.sw Q.sw R.sw S.sw T.sw U.sw V.sw W.sw X.sw Y.sw Z.sw b f h i j k l adieresis edieresis idieresis odieresis udieresis dotlessi thorn eth longs bracketright braceright question exclam parenright i i.TRK f.DEU f_f uniFB01 uniFB02 uniFB03 uniFB04 uniFB05 uniFB06 f_f.short f.short f_h f_k f_b f_t f_j longs_j longs_b longs_h longs_k longs.short longs_longs.short f_f_h f_f_k f_f_b f_f_t f_f_j longs_longs_j longs_longs_b longs_longs_h longs_longs_k longs_longs_t space exclam quotedbl quotesingle parenleft parenright comma period slash colon semicolon question bracketleft backslash bracketright braceleft bar braceright exclamdown questiondown guillemotleft guillemotright figuredash endash emdash uni2015 quoteleft quoteright quotesinglbase quotedblleft quotedblright quotedblbase ellipsis guilsinglleft guilsinglright
  1
-  SeqLookup: 0 "Single Substitution lookup 63" 
+  SeqLookup: 0 "Single Substitution lookup 63"
 EndFPST
-ChainSub2: coverage "Q_longtail contextual 1"  0 0 0 1
+ChainSub2: coverage "Q_longtail contextual 1" 0 0 0 1
  1 0 3
   Coverage: 1 Q
   FCoverage: 1878 A B C D E F G H I K L M N O P R S T U V W X Y Z a b c d e h i k l m n o r s t u v w x z Agrave Aacute Acircumflex Atilde Adieresis Aring AE Egrave Eacute Ecircumflex Edieresis Igrave Iacute Icircumflex Idieresis Eth Ntilde Ograve Oacute Ocircumflex Otilde Odieresis Oslash Ugrave Uacute Ucircumflex Udieresis Yacute Thorn agrave aacute acircumflex atilde adieresis aring ae egrave eacute ecircumflex edieresis igrave iacute icircumflex idieresis eth ntilde ograve oacute ocircumflex otilde odieresis oslash ugrave uacute ucircumflex udieresis Amacron amacron Abreve abreve Cacute cacute Ccircumflex ccircumflex Cdotaccent cdotaccent Ccaron ccaron Dcaron dcaron Dcroat dcroat Emacron emacron Ebreve ebreve Edotaccent edotaccent Ecaron ecaron Gcircumflex Gbreve Gdotaccent Hcircumflex hcircumflex Hbar hbar Itilde itilde Imacron imacron Ibreve ibreve Idotaccent dotlessi kgreenlandic Lacute lacute Lcaron lcaron Ldot ldot Lslash lslash Nacute nacute Ncaron ncaron napostrophe Omacron omacron Obreve obreve Ohungarumlaut ohungarumlaut OE oe Racute racute Rcaron rcaron Sacute sacute Scircumflex scircumflex Scaron scaron Tcaron tcaron Tbar tbar Utilde utilde Umacron umacron Ubreve ubreve Uring uring Uhungarumlaut uhungarumlaut Wcircumflex wcircumflex Ycircumflex Ydieresis Zacute zacute Zdotaccent zdotaccent Zcaron zcaron Ohorn ohorn Uhorn uhorn uni01C4 uni01C5 uni01C6 uni01CD uni01CE uni01CF uni01D0 uni01D1 uni01D2 uni01D3 uni01D4 uni01D5 uni01D6 uni01D7 uni01D8 uni01D9 uni01DA uni01DB uni01DC uni01DE uni01DF uni01E0 uni01E1 uni01E2 uni01E3 Gcaron uni01E8 uni01E9 uni01F1 uni01F2 uni01F3 uni01F4 uni01F8 uni01F9 Aringacute aringacute AEacute aeacute Oslashacute oslashacute uni0202 uni0203 uni0206 uni0207 uni020A uni020B uni020E uni020F uni0212 uni0213 uni0216 uni0217 uni021E uni021F uni0226 uni0227 uni022A uni022B uni022C uni022D uni022E uni022F uni0230 uni0231 uni0232
   FCoverage: 1878 A B C D E F G H I K L M N O P R S T U V W X Y Z a b c d e h i k l m n o r s t u v w x z Agrave Aacute Acircumflex Atilde Adieresis Aring AE Egrave Eacute Ecircumflex Edieresis Igrave Iacute Icircumflex Idieresis Eth Ntilde Ograve Oacute Ocircumflex Otilde Odieresis Oslash Ugrave Uacute Ucircumflex Udieresis Yacute Thorn agrave aacute acircumflex atilde adieresis aring ae egrave eacute ecircumflex edieresis igrave iacute icircumflex idieresis eth ntilde ograve oacute ocircumflex otilde odieresis oslash ugrave uacute ucircumflex udieresis Amacron amacron Abreve abreve Cacute cacute Ccircumflex ccircumflex Cdotaccent cdotaccent Ccaron ccaron Dcaron dcaron Dcroat dcroat Emacron emacron Ebreve ebreve Edotaccent edotaccent Ecaron ecaron Gcircumflex Gbreve Gdotaccent Hcircumflex hcircumflex Hbar hbar Itilde itilde Imacron imacron Ibreve ibreve Idotaccent dotlessi kgreenlandic Lacute lacute Lcaron lcaron Ldot ldot Lslash lslash Nacute nacute Ncaron ncaron napostrophe Omacron omacron Obreve obreve Ohungarumlaut ohungarumlaut OE oe Racute racute Rcaron rcaron Sacute sacute Scircumflex scircumflex Scaron scaron Tcaron tcaron Tbar tbar Utilde utilde Umacron umacron Ubreve ubreve Uring uring Uhungarumlaut uhungarumlaut Wcircumflex wcircumflex Ycircumflex Ydieresis Zacute zacute Zdotaccent zdotaccent Zcaron zcaron Ohorn ohorn Uhorn uhorn uni01C4 uni01C5 uni01C6 uni01CD uni01CE uni01CF uni01D0 uni01D1 uni01D2 uni01D3 uni01D4 uni01D5 uni01D6 uni01D7 uni01D8 uni01D9 uni01DA uni01DB uni01DC uni01DE uni01DF uni01E0 uni01E1 uni01E2 uni01E3 Gcaron uni01E8 uni01E9 uni01F1 uni01F2 uni01F3 uni01F4 uni01F8 uni01F9 Aringacute aringacute AEacute aeacute Oslashacute oslashacute uni0202 uni0203 uni0206 uni0207 uni020A uni020B uni020E uni020F uni0212 uni0213 uni0216 uni0217 uni021E uni021F uni0226 uni0227 uni022A uni022B uni022C uni022D uni022E uni022F uni0230 uni0231 uni0232
   FCoverage: 1880 A B C D E F G H I K L M N O P R S T U V W X Y Z a b c d e h i k l m n o r s t u v w x z Agrave Aacute Acircumflex Atilde Adieresis Aring AE Egrave Eacute Ecircumflex Edieresis Igrave Iacute Icircumflex Idieresis Eth Ntilde Ograve Oacute Ocircumflex Otilde Odieresis Oslash Ugrave Uacute Ucircumflex Udieresis Yacute Thorn agrave aacute acircumflex atilde adieresis aring ae egrave eacute ecircumflex edieresis igrave iacute icircumflex idieresis eth ntilde ograve oacute ocircumflex otilde odieresis oslash ugrave uacute ucircumflex udieresis Amacron amacron Abreve abreve Cacute cacute Ccircumflex ccircumflex Cdotaccent cdotaccent Ccaron ccaron Dcaron dcaron Dcroat dcroat Emacron emacron Ebreve ebreve Edotaccent edotaccent Ecaron ecaron Gcircumflex Gbreve Gdotaccent Hcircumflex hcircumflex Hbar hbar Itilde itilde Imacron imacron Ibreve ibreve Idotaccent dotlessi kgreenlandic Lacute lacute Lcaron lcaron Ldot ldot Lslash lslash Nacute nacute Ncaron ncaron napostrophe Omacron omacron Obreve obreve Ohungarumlaut ohungarumlaut OE oe Racute racute Rcaron rcaron Sacute sacute Scircumflex scircumflex Scaron scaron Tcaron tcaron Tbar tbar Utilde utilde Umacron umacron Ubreve ubreve Uring uring Uhungarumlaut uhungarumlaut Wcircumflex wcircumflex Ycircumflex Ydieresis Zacute zacute Zdotaccent zdotaccent Zcaron zcaron Ohorn ohorn Uhorn uhorn uni01C4 uni01C5 uni01C6 uni01CD uni01CE uni01CF uni01D0 uni01D1 uni01D2 uni01D3 uni01D4 uni01D5 uni01D6 uni01D7 uni01D8 uni01D9 uni01DA uni01DB uni01DC uni01DE uni01DF uni01E0 uni01E1 uni01E2 uni01E3 Gcaron uni01E8 uni01E9 uni01F1 uni01F2 uni01F3 uni01F4 uni01F8 uni01F9 Aringacute aringacute AEacute aeacute Oslashacute oslashacute uni0202 uni0203 uni0206 uni0207 uni020A uni020B uni020E uni020F uni0212 uni0213 uni0216 uni0217 uni021E uni021F uni0226 uni0227 uni022A uni022B uni022C uni022D uni022E uni022F uni0230 uni0231 uni0232 q
  1
-  SeqLookup: 0 "Single Substitution lookup 61" 
+  SeqLookup: 0 "Single Substitution lookup 61"
 EndFPST
-ChainSub2: coverage "Q_longtail contextual 0"  0 0 0 1
+ChainSub2: coverage "Q_longtail contextual 0" 0 0 0 1
  1 0 2
   Coverage: 1 Q
   FCoverage: 1878 A B C D E F G H I K L M N O P R S T U V W X Y Z a b c d e h i k l m n o r s t u v w x z Agrave Aacute Acircumflex Atilde Adieresis Aring AE Egrave Eacute Ecircumflex Edieresis Igrave Iacute Icircumflex Idieresis Eth Ntilde Ograve Oacute Ocircumflex Otilde Odieresis Oslash Ugrave Uacute Ucircumflex Udieresis Yacute Thorn agrave aacute acircumflex atilde adieresis aring ae egrave eacute ecircumflex edieresis igrave iacute icircumflex idieresis eth ntilde ograve oacute ocircumflex otilde odieresis oslash ugrave uacute ucircumflex udieresis Amacron amacron Abreve abreve Cacute cacute Ccircumflex ccircumflex Cdotaccent cdotaccent Ccaron ccaron Dcaron dcaron Dcroat dcroat Emacron emacron Ebreve ebreve Edotaccent edotaccent Ecaron ecaron Gcircumflex Gbreve Gdotaccent Hcircumflex hcircumflex Hbar hbar Itilde itilde Imacron imacron Ibreve ibreve Idotaccent dotlessi kgreenlandic Lacute lacute Lcaron lcaron Ldot ldot Lslash lslash Nacute nacute Ncaron ncaron napostrophe Omacron omacron Obreve obreve Ohungarumlaut ohungarumlaut OE oe Racute racute Rcaron rcaron Sacute sacute Scircumflex scircumflex Scaron scaron Tcaron tcaron Tbar tbar Utilde utilde Umacron umacron Ubreve ubreve Uring uring Uhungarumlaut uhungarumlaut Wcircumflex wcircumflex Ycircumflex Ydieresis Zacute zacute Zdotaccent zdotaccent Zcaron zcaron Ohorn ohorn Uhorn uhorn uni01C4 uni01C5 uni01C6 uni01CD uni01CE uni01CF uni01D0 uni01D1 uni01D2 uni01D3 uni01D4 uni01D5 uni01D6 uni01D7 uni01D8 uni01D9 uni01DA uni01DB uni01DC uni01DE uni01DF uni01E0 uni01E1 uni01E2 uni01E3 Gcaron uni01E8 uni01E9 uni01F1 uni01F2 uni01F3 uni01F4 uni01F8 uni01F9 Aringacute aringacute AEacute aeacute Oslashacute oslashacute uni0202 uni0203 uni0206 uni0207 uni020A uni020B uni020E uni020F uni0212 uni0213 uni0216 uni0217 uni021E uni021F uni0226 uni0227 uni022A uni022B uni022C uni022D uni022E uni022F uni0230 uni0231 uni0232
   FCoverage: 1878 A B C D E F G H I K L M N O P R S T U V W X Y Z a b c d e h i k l m n o r s t u v w x z Agrave Aacute Acircumflex Atilde Adieresis Aring AE Egrave Eacute Ecircumflex Edieresis Igrave Iacute Icircumflex Idieresis Eth Ntilde Ograve Oacute Ocircumflex Otilde Odieresis Oslash Ugrave Uacute Ucircumflex Udieresis Yacute Thorn agrave aacute acircumflex atilde adieresis aring ae egrave eacute ecircumflex edieresis igrave iacute icircumflex idieresis eth ntilde ograve oacute ocircumflex otilde odieresis oslash ugrave uacute ucircumflex udieresis Amacron amacron Abreve abreve Cacute cacute Ccircumflex ccircumflex Cdotaccent cdotaccent Ccaron ccaron Dcaron dcaron Dcroat dcroat Emacron emacron Ebreve ebreve Edotaccent edotaccent Ecaron ecaron Gcircumflex Gbreve Gdotaccent Hcircumflex hcircumflex Hbar hbar Itilde itilde Imacron imacron Ibreve ibreve Idotaccent dotlessi kgreenlandic Lacute lacute Lcaron lcaron Ldot ldot Lslash lslash Nacute nacute Ncaron ncaron napostrophe Omacron omacron Obreve obreve Ohungarumlaut ohungarumlaut OE oe Racute racute Rcaron rcaron Sacute sacute Scircumflex scircumflex Scaron scaron Tcaron tcaron Tbar tbar Utilde utilde Umacron umacron Ubreve ubreve Uring uring Uhungarumlaut uhungarumlaut Wcircumflex wcircumflex Ycircumflex Ydieresis Zacute zacute Zdotaccent zdotaccent Zcaron zcaron Ohorn ohorn Uhorn uhorn uni01C4 uni01C5 uni01C6 uni01CD uni01CE uni01CF uni01D0 uni01D1 uni01D2 uni01D3 uni01D4 uni01D5 uni01D6 uni01D7 uni01D8 uni01D9 uni01DA uni01DB uni01DC uni01DE uni01DF uni01E0 uni01E1 uni01E2 uni01E3 Gcaron uni01E8 uni01E9 uni01F1 uni01F2 uni01F3 uni01F4 uni01F8 uni01F9 Aringacute aringacute AEacute aeacute Oslashacute oslashacute uni0202 uni0203 uni0206 uni0207 uni020A uni020B uni020E uni020F uni0212 uni0213 uni0216 uni0217 uni021E uni021F uni0226 uni0227 uni022A uni022B uni022C uni022D uni022E uni022F uni0230 uni0231 uni0232
  1
-  SeqLookup: 0 "Single Substitution lookup 60" 
+  SeqLookup: 0 "Single Substitution lookup 60"
 EndFPST
-ChainSub2: glyph "liga_final_s2 contextual 3"  0 0 0 1
+ChainSub2: glyph "liga_final_s2 contextual 3" 0 0 0 1
  String: 3 u s
  BString: 0 
  FString: 0 
  1
-  SeqLookup: 0 "Ligature Substitution lookup 58" 
+  SeqLookup: 0 "Ligature Substitution lookup 58"
 EndFPST
-ChainSub2: glyph "liga_final_s2 contextual 2"  0 0 0 1
+ChainSub2: glyph "liga_final_s2 contextual 2" 0 0 0 1
  String: 3 i s
  BString: 0 
  FString: 0 
  1
-  SeqLookup: 0 "Ligature Substitution lookup 57" 
+  SeqLookup: 0 "Ligature Substitution lookup 57"
 EndFPST
-ChainSub2: glyph "liga_final_s2 contextual 1"  0 0 0 1
+ChainSub2: glyph "liga_final_s2 contextual 1" 0 0 0 1
  String: 3 a s
  BString: 0 
  FString: 0 
  1
-  SeqLookup: 0 "Ligature Substitution lookup 56" 
+  SeqLookup: 0 "Ligature Substitution lookup 56"
 EndFPST
-ChainSub2: coverage "liga_final_s2 contextual 0"  0 0 0 1
+ChainSub2: coverage "liga_final_s2 contextual 0" 0 0 0 1
  2 0 1
   Coverage: 5 a i u
   Coverage: 1 s
   FCoverage: 530 a b c d e f g h i j k l m n o p q r s t u v w x y z longs germandbls adieresis edieresis odieresis udieresis idieresis aacute eacute iacute oacute uacute agrave egrave igrave ograve ugrave atilde etilde otilde utilde oe f.DEU f.short i.TRK l.CAT u.LAT v.LATmedi longs.short v.init w.init v.alt w.alt f_f unifb01 unifb02 unifb03 unifb04 unifb05 unifb06 longs_longs_l longs_longs_i longs_i longs_longs longs_l T_h c_h c_k longs_s s_s c_t f_f.short t_t t_z f_h f_k f_b f_t f_j longs_j longs_b longs_h longs_k longs_longs.short hyphen
  0
 EndFPST
-ChainSub2: coverage "liga_final_s1 contextual 2"  0 0 0 1
+ChainSub2: coverage "liga_final_s1 contextual 2" 0 0 0 1
  2 0 2
   Coverage: 1 u
   Coverage: 1 s
   FCoverage: 6 hyphen
   FCoverage: 1472 A B C D E F G H I J K L M N O P Q R S T U V W X Y Z Agrave Aacute Acircumflex Atilde Adieresis Aring AE Ccedilla Egrave Eacute Ecircumflex Edieresis Igrave Iacute Icircumflex Idieresis Eth Ntilde Ograve Oacute Ocircumflex Otilde Odieresis Oslash Ugrave Uacute Ucircumflex Udieresis Yacute Thorn Amacron Abreve Aogonek Cacute Ccircumflex Cdotaccent Ccaron Dcaron Dcroat Emacron Ebreve Edotaccent Eogonek Ecaron Gcircumflex Gbreve Gdotaccent uni0122 Hcircumflex Hbar Itilde Imacron Ibreve Iogonek Idotaccent IJ Jcircumflex uni0136 Lacute uni013B Lcaron Ldot Lslash Nacute uni0145 Ncaron Eng Omacron Obreve Ohungarumlaut OE Racute uni0156 Rcaron Sacute Scircumflex Scedilla Scaron uni0162 Tcaron Tbar Utilde Umacron Ubreve Uring Uhungarumlaut Uogonek Wcircumflex Ycircumflex Ydieresis Zacute Zdotaccent Zcaron L.CAT U.LAT A.sw B.sw C.sw D.sw E.sw F.sw G.sw H.sw I.sw J.sw K.sw L.sw M.sw N.sw O.sw P.sw Q.sw R.sw S.sw T.sw U.sw V.sw W.sw X.sw Y.sw Z.sw a b c d e f g h i j k l m n o p q r s t u v w x y z longs germandbls adieresis edieresis odieresis udieresis idieresis aacute eacute iacute oacute uacute agrave egrave igrave ograve ugrave atilde etilde otilde utilde oe f.DEU f.short i.TRK l.CAT u.LAT v.LATmedi longs.short v.init w.init v.alt w.alt f_f unifb01 unifb02 unifb03 unifb04 unifb05 unifb06 longs_longs_l longs_longs_i longs_i longs_longs longs_l T_h c_h c_k longs_s s_s c_t f_f.short t_t t_z f_h f_k f_b f_t f_j longs_j longs_b longs_h longs_k longs_longs.short
  1
-  SeqLookup: 0 "Ligature Substitution lookup 54" 
+  SeqLookup: 0 "Ligature Substitution lookup 54"
 EndFPST
-ChainSub2: coverage "liga_final_s1 contextual 1"  0 0 0 1
+ChainSub2: coverage "liga_final_s1 contextual 1" 0 0 0 1
  2 0 2
   Coverage: 1 i
   Coverage: 1 s
   FCoverage: 6 hyphen
   FCoverage: 1472 A B C D E F G H I J K L M N O P Q R S T U V W X Y Z Agrave Aacute Acircumflex Atilde Adieresis Aring AE Ccedilla Egrave Eacute Ecircumflex Edieresis Igrave Iacute Icircumflex Idieresis Eth Ntilde Ograve Oacute Ocircumflex Otilde Odieresis Oslash Ugrave Uacute Ucircumflex Udieresis Yacute Thorn Amacron Abreve Aogonek Cacute Ccircumflex Cdotaccent Ccaron Dcaron Dcroat Emacron Ebreve Edotaccent Eogonek Ecaron Gcircumflex Gbreve Gdotaccent uni0122 Hcircumflex Hbar Itilde Imacron Ibreve Iogonek Idotaccent IJ Jcircumflex uni0136 Lacute uni013B Lcaron Ldot Lslash Nacute uni0145 Ncaron Eng Omacron Obreve Ohungarumlaut OE Racute uni0156 Rcaron Sacute Scircumflex Scedilla Scaron uni0162 Tcaron Tbar Utilde Umacron Ubreve Uring Uhungarumlaut Uogonek Wcircumflex Ycircumflex Ydieresis Zacute Zdotaccent Zcaron L.CAT U.LAT A.sw B.sw C.sw D.sw E.sw F.sw G.sw H.sw I.sw J.sw K.sw L.sw M.sw N.sw O.sw P.sw Q.sw R.sw S.sw T.sw U.sw V.sw W.sw X.sw Y.sw Z.sw a b c d e f g h i j k l m n o p q r s t u v w x y z longs germandbls adieresis edieresis odieresis udieresis idieresis aacute eacute iacute oacute uacute agrave egrave igrave ograve ugrave atilde etilde otilde utilde oe f.DEU f.short i.TRK l.CAT u.LAT v.LATmedi longs.short v.init w.init v.alt w.alt f_f unifb01 unifb02 unifb03 unifb04 unifb05 unifb06 longs_longs_l longs_longs_i longs_i longs_longs longs_l T_h c_h c_k longs_s s_s c_t f_f.short t_t t_z f_h f_k f_b f_t f_j longs_j longs_b longs_h longs_k longs_longs.short
  1
-  SeqLookup: 0 "Ligature Substitution lookup 53" 
+  SeqLookup: 0 "Ligature Substitution lookup 53"
 EndFPST
-ChainSub2: coverage "liga_final_s1 contextual 0"  0 0 0 1
+ChainSub2: coverage "liga_final_s1 contextual 0" 0 0 0 1
  2 0 2
   Coverage: 1 a
   Coverage: 1 s
   FCoverage: 6 hyphen
   FCoverage: 1472 A B C D E F G H I J K L M N O P Q R S T U V W X Y Z Agrave Aacute Acircumflex Atilde Adieresis Aring AE Ccedilla Egrave Eacute Ecircumflex Edieresis Igrave Iacute Icircumflex Idieresis Eth Ntilde Ograve Oacute Ocircumflex Otilde Odieresis Oslash Ugrave Uacute Ucircumflex Udieresis Yacute Thorn Amacron Abreve Aogonek Cacute Ccircumflex Cdotaccent Ccaron Dcaron Dcroat Emacron Ebreve Edotaccent Eogonek Ecaron Gcircumflex Gbreve Gdotaccent uni0122 Hcircumflex Hbar Itilde Imacron Ibreve Iogonek Idotaccent IJ Jcircumflex uni0136 Lacute uni013B Lcaron Ldot Lslash Nacute uni0145 Ncaron Eng Omacron Obreve Ohungarumlaut OE Racute uni0156 Rcaron Sacute Scircumflex Scedilla Scaron uni0162 Tcaron Tbar Utilde Umacron Ubreve Uring Uhungarumlaut Uogonek Wcircumflex Ycircumflex Ydieresis Zacute Zdotaccent Zcaron L.CAT U.LAT A.sw B.sw C.sw D.sw E.sw F.sw G.sw H.sw I.sw J.sw K.sw L.sw M.sw N.sw O.sw P.sw Q.sw R.sw S.sw T.sw U.sw V.sw W.sw X.sw Y.sw Z.sw a b c d e f g h i j k l m n o p q r s t u v w x y z longs germandbls adieresis edieresis odieresis udieresis idieresis aacute eacute iacute oacute uacute agrave egrave igrave ograve ugrave atilde etilde otilde utilde oe f.DEU f.short i.TRK l.CAT u.LAT v.LATmedi longs.short v.init w.init v.alt w.alt f_f unifb01 unifb02 unifb03 unifb04 unifb05 unifb06 longs_longs_l longs_longs_i longs_i longs_longs longs_l T_h c_h c_k longs_s s_s c_t f_f.short t_t t_z f_h f_k f_b f_t f_j longs_j longs_b longs_h longs_k longs_longs.short
  1
-  SeqLookup: 0 "Ligature Substitution lookup 52" 
+  SeqLookup: 0 "Ligature Substitution lookup 52"
 EndFPST
-ChainSub2: coverage "frac contextual 1"  0 0 0 1
+ChainSub2: coverage "frac contextual 1" 0 0 0 1
  1 0 1
   Coverage: 49 zero one two three four five six seven eight nine
   FCoverage: 164 slash fraction zero one two three four five six seven eight nine zero.ordn one.ordn two.ordn three.ordn four.ordn five.ordn six.ordn seven.ordn eight.ordn nine.ordn
  1
-  SeqLookup: 0 "Single Substitution lookup 41" 
+  SeqLookup: 0 "Single Substitution lookup 41"
 EndFPST
-ChainSub2: coverage "frac contextual 0"  0 0 0 1
+ChainSub2: coverage "frac contextual 0" 0 0 0 1
  1 1 0
   Coverage: 49 zero one two three four five six seven eight nine
   BCoverage: 164 slash fraction zero one two three four five six seven eight nine zero.subs one.subs two.subs three.subs four.subs five.subs six.subs seven.subs eight.subs nine.subs
  1
-  SeqLookup: 0 "Single Substitution lookup 40" 
+  SeqLookup: 0 "Single Substitution lookup 40"
 EndFPST
-ChainSub2: coverage "longs_replacement subtable"  0 0 0 1
+ChainSub2: coverage "longs_replacement subtable" 0 0 0 1
  1 0 1
   Coverage: 1 s
   FCoverage: 288 a b c d e f g h i j k l m n o p q r s t u v w x y z longs germandbls adieresis edieresis odieresis udieresis idieresis aacute eacute iacute oacute uacute agrave egrave igrave ograve ugrave atilde etilde otilde utilde oe f.DEU f.short i.TRK l.CAT u.LAT v.LATmedi longs.short hyphen uni200D
  1
-  SeqLookup: 0 "Single Substitution lookup 29" 
+  SeqLookup: 0 "Single Substitution lookup 29"
 EndFPST
-ChainSub2: glyph "historic_u contextual 3"  0 0 0 1
+ChainSub2: glyph "historic_u contextual 3" 0 0 0 1
  String: 1 U
  BString: 0 
  FString: 0 
  1
-  SeqLookup: 0 "Single Substitution lookup 26" 
+  SeqLookup: 0 "Single Substitution lookup 26"
 EndFPST
-ChainSub2: coverage "historic_u contextual 2"  0 0 0 1
+ChainSub2: coverage "historic_u contextual 2" 0 0 0 1
  1 1 0
   Coverage: 1 v
   BCoverage: 1483 A B C D E F G H I J K L M N O P Q R S T U V W X Y Z Agrave Aacute Acircumflex Atilde Adieresis Aring AE Ccedilla Egrave Eacute Ecircumflex Edieresis Igrave Iacute Icircumflex Idieresis Eth Ntilde Ograve Oacute Ocircumflex Otilde Odieresis Oslash Ugrave Uacute Ucircumflex Udieresis Yacute Thorn Amacron Abreve Aogonek Cacute Ccircumflex Cdotaccent Ccaron Dcaron Dcroat Emacron Ebreve Edotaccent Eogonek Ecaron Gcircumflex Gbreve Gdotaccent uni0122 Hcircumflex Hbar Itilde Imacron Ibreve Iogonek Idotaccent IJ Jcircumflex uni0136 Lacute uni013B Lcaron Ldot Lslash Nacute uni0145 Ncaron Eng Omacron Obreve Ohungarumlaut OE Racute uni0156 Rcaron Sacute Scircumflex Scedilla Scaron uni0162 Tcaron Tbar Utilde Umacron Ubreve Uring Uhungarumlaut Uogonek Wcircumflex Ycircumflex Ydieresis Zacute Zdotaccent Zcaron L.CAT U.LAT A.sw B.sw C.sw D.sw E.sw F.sw G.sw H.sw I.sw J.sw K.sw L.sw M.sw N.sw O.sw P.sw Q.sw R.sw S.sw T.sw U.sw V.sw W.sw X.sw Y.sw Z.sw a b c d e f g h i j k l m n o p q r s t u v w x y z longs germandbls adieresis edieresis odieresis udieresis idieresis aacute eacute iacute oacute uacute agrave egrave igrave ograve ugrave atilde etilde otilde utilde oe f.DEU f.short i.TRK l.CAT u.LAT v.LATmedi longs.short v.init w.init v.alt w.alt f_f unifb01 unifb02 unifb03 unifb04 unifb05 unifb06 longs_longs_l longs_longs_i longs_i longs_longs longs_l T_h c_h c_k longs_s s_s c_t f_f.short t_t t_z f_h f_k f_b f_t f_j longs_j longs_b longs_h longs_k longs_longs.short quoteright
  1
-  SeqLookup: 0 "Single Substitution lookup 25" 
+  SeqLookup: 0 "Single Substitution lookup 25"
 EndFPST
-ChainSub2: glyph "historic_u contextual 1"  0 0 0 1
+ChainSub2: glyph "historic_u contextual 1" 0 0 0 1
  String: 1 u
  BString: 0 
  FString: 0 
  1
-  SeqLookup: 0 "Single Substitution lookup 24" 
+  SeqLookup: 0 "Single Substitution lookup 24"
 EndFPST
-ChainSub2: coverage "historic_u contextual 0"  0 0 0 1
+ChainSub2: coverage "historic_u contextual 0" 0 0 0 1
  1 1 0
   Coverage: 1 u
   BCoverage: 1483 A B C D E F G H I J K L M N O P Q R S T U V W X Y Z Agrave Aacute Acircumflex Atilde Adieresis Aring AE Ccedilla Egrave Eacute Ecircumflex Edieresis Igrave Iacute Icircumflex Idieresis Eth Ntilde Ograve Oacute Ocircumflex Otilde Odieresis Oslash Ugrave Uacute Ucircumflex Udieresis Yacute Thorn Amacron Abreve Aogonek Cacute Ccircumflex Cdotaccent Ccaron Dcaron Dcroat Emacron Ebreve Edotaccent Eogonek Ecaron Gcircumflex Gbreve Gdotaccent uni0122 Hcircumflex Hbar Itilde Imacron Ibreve Iogonek Idotaccent IJ Jcircumflex uni0136 Lacute uni013B Lcaron Ldot Lslash Nacute uni0145 Ncaron Eng Omacron Obreve Ohungarumlaut OE Racute uni0156 Rcaron Sacute Scircumflex Scedilla Scaron uni0162 Tcaron Tbar Utilde Umacron Ubreve Uring Uhungarumlaut Uogonek Wcircumflex Ycircumflex Ydieresis Zacute Zdotaccent Zcaron L.CAT U.LAT A.sw B.sw C.sw D.sw E.sw F.sw G.sw H.sw I.sw J.sw K.sw L.sw M.sw N.sw O.sw P.sw Q.sw R.sw S.sw T.sw U.sw V.sw W.sw X.sw Y.sw Z.sw a b c d e f g h i j k l m n o p q r s t u v w x y z longs germandbls adieresis edieresis odieresis udieresis idieresis aacute eacute iacute oacute uacute agrave egrave igrave ograve ugrave atilde etilde otilde utilde oe f.DEU f.short i.TRK l.CAT u.LAT v.LATmedi longs.short v.init w.init v.alt w.alt f_f unifb01 unifb02 unifb03 unifb04 unifb05 unifb06 longs_longs_l longs_longs_i longs_i longs_longs longs_l T_h c_h c_k longs_s s_s c_t f_f.short t_t t_z f_h f_k f_b f_t f_j longs_j longs_b longs_h longs_k longs_longs.short quoteright
  0
 EndFPST
-ChainSub2: coverage "CCMP_stackgrk2 subtable"  0 0 0 1
+ChainSub2: coverage "CCMP_stackgrk2 subtable" 0 0 0 1
  1 1 0
   Coverage: 19 gravecomb acutecomb
   BCoverage: 23 uni0313.grk uni0314.grk
  1
-  SeqLookup: 0 "Single Substitution lookup 20" 
+  SeqLookup: 0 "Single Substitution lookup 20"
 EndFPST
-ChainSub2: coverage "CCMP_stackgrk1 contextual 3"  0 0 0 1
+ChainSub2: coverage "CCMP_stackgrk1 contextual 3" 0 0 0 1
  1 1 0
   Coverage: 19 gravecomb acutecomb
   BCoverage: 89 alpha epsilon eta iota omicron upsilon omega Alpha Epsilon Eta Iota Omicron Upsilon Omega
  1
-  SeqLookup: 0 "Single Substitution lookup 18" 
+  SeqLookup: 0 "Single Substitution lookup 18"
 EndFPST
-ChainSub2: coverage "CCMP_stackgrk1 contextual 2"  0 0 0 1
+ChainSub2: coverage "CCMP_stackgrk1 contextual 2" 0 0 0 1
  1 1 1
   Coverage: 15 uni0313 uni0314
   BCoverage: 89 alpha epsilon eta iota omicron upsilon omega Alpha Epsilon Eta Iota Omicron Upsilon Omega
   FCoverage: 19 uni0342 uni0342.alt
  1
-  SeqLookup: 0 "Single Substitution lookup 17" 
+  SeqLookup: 0 "Single Substitution lookup 17"
 EndFPST
-ChainSub2: coverage "CCMP_stackgrk1 contextual 1"  0 0 0 1
+ChainSub2: coverage "CCMP_stackgrk1 contextual 1" 0 0 0 1
  1 1 1
   Coverage: 15 uni0313 uni0314
   BCoverage: 89 alpha epsilon eta iota omicron upsilon omega Alpha Epsilon Eta Iota Omicron Upsilon Omega
   FCoverage: 19 gravecomb acutecomb
  1
-  SeqLookup: 0 "Single Substitution lookup 16" 
+  SeqLookup: 0 "Single Substitution lookup 16"
 EndFPST
-ChainSub2: coverage "CCMP_stackgrk1 contextual 0"  0 0 0 1
+ChainSub2: coverage "CCMP_stackgrk1 contextual 0" 0 0 0 1
  1 1 1
   Coverage: 7 uni0308
   BCoverage: 89 alpha epsilon eta iota omicron upsilon omega Alpha Epsilon Eta Iota Omicron Upsilon Omega
   FCoverage: 19 gravecomb acutecomb
  1
-  SeqLookup: 0 "Single Substitution lookup 15" 
+  SeqLookup: 0 "Single Substitution lookup 15"
 EndFPST
-ChainSub2: coverage "CCMP_stacking2 subtable"  0 0 0 1
+ChainSub2: coverage "CCMP_stacking2 subtable" 0 0 0 1
  1 1 0
   Coverage: 19 acutecomb gravecomb
   BCoverage: 13 uni0302.stack
  1
-  SeqLookup: 0 "Single Substitution lookup 13" 
+  SeqLookup: 0 "Single Substitution lookup 13"
 EndFPST
-ChainSub2: coverage "CCMP_stacking1 subtable"  0 0 0 1
+ChainSub2: coverage "CCMP_stacking1 subtable" 0 0 0 1
  1 0 1
   Coverage: 7 uni0302
   FCoverage: 19 acutecomb gravecomb
  1
-  SeqLookup: 0 "Single Substitution lookup 11" 
+  SeqLookup: 0 "Single Substitution lookup 11"
 EndFPST
-ChainSub2: coverage "CCMP_contextual contextual 1"  0 0 0 1
+ChainSub2: coverage "CCMP_contextual contextual 1" 0 0 0 1
  1 1 0
   Coverage: 7 uni030C
   BCoverage: 5 l d t
  1
-  SeqLookup: 0 "Single Substitution lookup 9" 
+  SeqLookup: 0 "Single Substitution lookup 9"
 EndFPST
-ChainSub2: coverage "CCMP_contextual contextual 0"  0 0 0 1
+ChainSub2: coverage "CCMP_contextual contextual 0" 0 0 0 1
  1 0 1
   Coverage: 3 i j
   FCoverage: 165 gravecomb acutecomb uni0302 tildecomb uni0304 uni0306 uni0307 uni0308 uni0309 uni030A uni030B uni030C uni030D uni030E uni030F uni0310 uni0311 uni0312 uni0313 uni0314
  1
-  SeqLookup: 0 "Single Substitution lookup 8" 
+  SeqLookup: 0 "Single Substitution lookup 8"
 EndFPST
 ShortTable: maxp 16
   1
@@ -376,40 +377,40 @@ ShortTable: maxp 16
   0
   0
 EndShort
-LangName: 1055 "" "" "+ATAA-talik" 
-LangName: 1053 "" "" "Kursiv" 
-LangName: 1034 "" "" "Cursiva" 
-LangName: 3082 "" "" "Cursiva" 
-LangName: 2058 "" "" "Cursiva" 
-LangName: 1060 "" "" "Po+AWEA-evno" 
-LangName: 1051 "" "" "Kurz+AO0A-va" 
-LangName: 1049 "" "" "+BBoEQwRABEEEOAQy" 
-LangName: 1046 "" "" "It+AOEA-lico" 
-LangName: 2070 "" "" "It+AOEA-lico" 
-LangName: 1045 "" "" "Kursywa" 
-LangName: 1044 "" "" "Kursiv" 
-LangName: 1040 "" "" "Corsivo" 
-LangName: 1038 "" "" "D+AVEA-lt" 
-LangName: 1032 "" "" "+A6ADuwOsA7MDuQOx" 
-LangName: 1036 "" "" "Italique" 
-LangName: 3084 "" "" "Italique" 
-LangName: 1035 "" "" "Kursivoitu" 
-LangName: 1043 "" "" "Cursief" 
-LangName: 1030 "" "" "kursiv" 
-LangName: 1029 "" "" "kurz+AO0A-va" 
-LangName: 1027 "" "" "Cursiva" 
-LangName: 1069 "" "" "Etzana" 
-LangName: 1033 "" "" "" "" "" "" "" "" "" "" "" "" "" "Copyright (c) 2012, Georg A. Duffner, (<URL|email>).+AAoACgAA-This Font Software is licensed under the SIL Open Font License, Version 1.1.+AAoA-This license is copied below, and is also available with a FAQ at:+AAoA-http://scripts.sil.org/OFL+AAoACgAK------------------------------------------------------------+AAoA-SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007+AAoA------------------------------------------------------------+AAoACgAA-PREAMBLE+AAoA-The goals of the Open Font License (OFL) are to stimulate worldwide+AAoA-development of collaborative font projects, to support the font creation+AAoA-efforts of academic and linguistic communities, and to provide a free and+AAoA-open framework in which fonts may be shared and improved in partnership+AAoA-with others.+AAoACgAA-The OFL allows the licensed fonts to be used, studied, modified and+AAoA-redistributed freely as long as they are not sold by themselves. The+AAoA-fonts, including any derivative works, can be bundled, embedded, +AAoA-redistributed and/or sold with any software provided that any reserved+AAoA-names are not used by derivative works. The fonts and derivatives,+AAoA-however, cannot be released under any other type of license. The+AAoA-requirement for fonts to remain under this license does not apply+AAoA-to any document created using the fonts or their derivatives.+AAoACgAA-DEFINITIONS+AAoAIgAA-Font Software+ACIA refers to the set of files released by the Copyright+AAoA-Holder(s) under this license and clearly marked as such. This may+AAoA-include source files, build scripts and documentation.+AAoACgAi-Reserved Font Name+ACIA refers to any names specified as such after the+AAoA-copyright statement(s).+AAoACgAi-Original Version+ACIA refers to the collection of Font Software components as+AAoA-distributed by the Copyright Holder(s).+AAoACgAi-Modified Version+ACIA refers to any derivative made by adding to, deleting,+AAoA-or substituting -- in part or in whole -- any of the components of the+AAoA-Original Version, by changing formats or by porting the Font Software to a+AAoA-new environment.+AAoACgAi-Author+ACIA refers to any designer, engineer, programmer, technical+AAoA-writer or other person who contributed to the Font Software.+AAoACgAA-PERMISSION & CONDITIONS+AAoA-Permission is hereby granted, free of charge, to any person obtaining+AAoA-a copy of the Font Software, to use, study, copy, merge, embed, modify,+AAoA-redistribute, and sell modified and unmodified copies of the Font+AAoA-Software, subject to the following conditions:+AAoACgAA-1) Neither the Font Software nor any of its individual components,+AAoA-in Original or Modified Versions, may be sold by itself.+AAoACgAA-2) Original or Modified Versions of the Font Software may be bundled,+AAoA-redistributed and/or sold with any software, provided that each copy+AAoA-contains the above copyright notice and this license. These can be+AAoA-included either as stand-alone text files, human-readable headers or+AAoA-in the appropriate machine-readable metadata fields within text or+AAoA-binary files as long as those fields can be easily viewed by the user.+AAoACgAA-3) No Modified Version of the Font Software may use the Reserved Font+AAoA-Name(s) unless explicit written permission is granted by the corresponding+AAoA-Copyright Holder. This restriction only applies to the primary font name as+AAoA-presented to the users.+AAoACgAA-4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font+AAoA-Software shall not be used to promote, endorse or advertise any+AAoA-Modified Version, except to acknowledge the contribution(s) of the+AAoA-Copyright Holder(s) and the Author(s) or with their explicit written+AAoA-permission.+AAoACgAA-5) The Font Software, modified or unmodified, in part or in whole,+AAoA-must be distributed entirely under this license, and must not be+AAoA-distributed under any other license. The requirement for fonts to+AAoA-remain under this license does not apply to any document created+AAoA-using the Font Software.+AAoACgAA-TERMINATION+AAoA-This license becomes null and void if any of the above conditions are+AAoA-not met.+AAoACgAA-DISCLAIMER+AAoA-THE FONT SOFTWARE IS PROVIDED +ACIA-AS IS+ACIA, WITHOUT WARRANTY OF ANY KIND,+AAoA-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF+AAoA-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT+AAoA-OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE+AAoA-COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,+AAoA-INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL+AAoA-DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING+AAoA-FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM+AAoA-OTHER DEALINGS IN THE FONT SOFTWARE." "http://scripts.sil.org/OFL" "" "EB Garamond" "08 Italic" "EB Garamond 08 Italic" 
-LangName: 1031 "" "" "Kursiv" 
+LangName: 1055 "" "" "+ATAA-talik"
+LangName: 1053 "" "" "Kursiv"
+LangName: 1034 "" "" "Cursiva"
+LangName: 3082 "" "" "Cursiva"
+LangName: 2058 "" "" "Cursiva"
+LangName: 1060 "" "" "Po+AWEA-evno"
+LangName: 1051 "" "" "Kurz+AO0A-va"
+LangName: 1049 "" "" "+BBoEQwRABEEEOAQy"
+LangName: 1046 "" "" "It+AOEA-lico"
+LangName: 2070 "" "" "It+AOEA-lico"
+LangName: 1045 "" "" "Kursywa"
+LangName: 1044 "" "" "Kursiv"
+LangName: 1040 "" "" "Corsivo"
+LangName: 1038 "" "" "D+AVEA-lt"
+LangName: 1032 "" "" "+A6ADuwOsA7MDuQOx"
+LangName: 1036 "" "" "Italique"
+LangName: 3084 "" "" "Italique"
+LangName: 1035 "" "" "Kursivoitu"
+LangName: 1043 "" "" "Cursief"
+LangName: 1030 "" "" "kursiv"
+LangName: 1029 "" "" "kurz+AO0A-va"
+LangName: 1027 "" "" "Cursiva"
+LangName: 1069 "" "" "Etzana"
+LangName: 1033 "" "" "" "" "" "" "" "" "" "" "" "" "" "Copyright (c) 2012, Georg A. Duffner, (<URL|email>).+AAoACgAA-This Font Software is licensed under the SIL Open Font License, Version 1.1.+AAoA-This license is copied below, and is also available with a FAQ at:+AAoA-http://scripts.sil.org/OFL+AAoACgAK------------------------------------------------------------+AAoA-SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007+AAoA------------------------------------------------------------+AAoACgAA-PREAMBLE+AAoA-The goals of the Open Font License (OFL) are to stimulate worldwide+AAoA-development of collaborative font projects, to support the font creation+AAoA-efforts of academic and linguistic communities, and to provide a free and+AAoA-open framework in which fonts may be shared and improved in partnership+AAoA-with others.+AAoACgAA-The OFL allows the licensed fonts to be used, studied, modified and+AAoA-redistributed freely as long as they are not sold by themselves. The+AAoA-fonts, including any derivative works, can be bundled, embedded, +AAoA-redistributed and/or sold with any software provided that any reserved+AAoA-names are not used by derivative works. The fonts and derivatives,+AAoA-however, cannot be released under any other type of license. The+AAoA-requirement for fonts to remain under this license does not apply+AAoA-to any document created using the fonts or their derivatives.+AAoACgAA-DEFINITIONS+AAoAIgAA-Font Software+ACIA refers to the set of files released by the Copyright+AAoA-Holder(s) under this license and clearly marked as such. This may+AAoA-include source files, build scripts and documentation.+AAoACgAi-Reserved Font Name+ACIA refers to any names specified as such after the+AAoA-copyright statement(s).+AAoACgAi-Original Version+ACIA refers to the collection of Font Software components as+AAoA-distributed by the Copyright Holder(s).+AAoACgAi-Modified Version+ACIA refers to any derivative made by adding to, deleting,+AAoA-or substituting -- in part or in whole -- any of the components of the+AAoA-Original Version, by changing formats or by porting the Font Software to a+AAoA-new environment.+AAoACgAi-Author+ACIA refers to any designer, engineer, programmer, technical+AAoA-writer or other person who contributed to the Font Software.+AAoACgAA-PERMISSION & CONDITIONS+AAoA-Permission is hereby granted, free of charge, to any person obtaining+AAoA-a copy of the Font Software, to use, study, copy, merge, embed, modify,+AAoA-redistribute, and sell modified and unmodified copies of the Font+AAoA-Software, subject to the following conditions:+AAoACgAA-1) Neither the Font Software nor any of its individual components,+AAoA-in Original or Modified Versions, may be sold by itself.+AAoACgAA-2) Original or Modified Versions of the Font Software may be bundled,+AAoA-redistributed and/or sold with any software, provided that each copy+AAoA-contains the above copyright notice and this license. These can be+AAoA-included either as stand-alone text files, human-readable headers or+AAoA-in the appropriate machine-readable metadata fields within text or+AAoA-binary files as long as those fields can be easily viewed by the user.+AAoACgAA-3) No Modified Version of the Font Software may use the Reserved Font+AAoA-Name(s) unless explicit written permission is granted by the corresponding+AAoA-Copyright Holder. This restriction only applies to the primary font name as+AAoA-presented to the users.+AAoACgAA-4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font+AAoA-Software shall not be used to promote, endorse or advertise any+AAoA-Modified Version, except to acknowledge the contribution(s) of the+AAoA-Copyright Holder(s) and the Author(s) or with their explicit written+AAoA-permission.+AAoACgAA-5) The Font Software, modified or unmodified, in part or in whole,+AAoA-must be distributed entirely under this license, and must not be+AAoA-distributed under any other license. The requirement for fonts to+AAoA-remain under this license does not apply to any document created+AAoA-using the Font Software.+AAoACgAA-TERMINATION+AAoA-This license becomes null and void if any of the above conditions are+AAoA-not met.+AAoACgAA-DISCLAIMER+AAoA-THE FONT SOFTWARE IS PROVIDED +ACIA-AS IS+ACIA, WITHOUT WARRANTY OF ANY KIND,+AAoA-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF+AAoA-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT+AAoA-OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE+AAoA-COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,+AAoA-INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL+AAoA-DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING+AAoA-FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM+AAoA-OTHER DEALINGS IN THE FONT SOFTWARE." "http://scripts.sil.org/OFL" "" "EB Garamond" "08 Italic" "EB Garamond 08 Italic"
+LangName: 1031 "" "" "Kursiv"
 GaspTable: 1 65535 2 0
-DesignSize: 80 0-94 2 1033 "Italic" 
+DesignSize: 80 0-94 2 1033 "Italic"
 Encoding: Custom
 UnicodeInterp: none
 NameList: AGL For New Fonts
 DisplaySize: -96
 AntiAlias: 1
 FitToEm: 1
-WinInfo: 0 8 5
+WinInfo: 2014 19 8
 BeginPrivate: 9
 BlueValues 39 [-81 8 396 405 513 555 598 632 661 691]
 OtherBlues 11 [-318 -299]
@@ -443,5 +444,5 @@ Grid
  319 599 332 604 366 604 c 0
 EndSplineSet
 TeXData: 1 8388608 1038727 254803 127401 84934 450888 1048576 84934 783286 444596 497025 792723 393216 433062 380633 303038 157286 324010 404750 52429 2506097 1059062 262144
-AnchorClass2: "top_accent"  "mark anchor 0" "ogonek"  "mark anchor 1" "cedilla"  "mark anchor 2" "top_stack"  "mkmk subtable" "acutestack"  "mkmk subtable" "gravestack"  "mkmk subtable" "hookstack"  "mkmk subtable" "grk_hstack"  "mkmk subtable" 
+AnchorClass2: "top_accent" "mark anchor 0" "ogonek" "mark anchor 1" "cedilla" "mark anchor 2" "top_stack" "mkmk subtable" "acutestack" "mkmk subtable" "gravestack" "mkmk subtable" "hookstack" "mkmk subtable" "grk_hstack" "mkmk subtable"
 EndSplineFont

--- a/SFD/EBGaramond08-Italic.sfdir/i_s.glyph
+++ b/SFD/EBGaramond08-Italic.sfdir/i_s.glyph
@@ -39,7 +39,7 @@ SplineSet
  179.474609375 527 164 545.474609375 164 572 c 0
  164 600.685546875 190.314453125 629 219 629 c 0
 EndSplineSet
-LCarets2: 1 264 
+LCarets2: 1 264
 Ligature2: "Ligature Substitution lookup 57 subtable" i s
 Ligature2: "Ligature Substitution lookup 53 subtable" i s
 EndChar

--- a/SFD/EBGaramond08-Italic.sfdir/l_l.glyph
+++ b/SFD/EBGaramond08-Italic.sfdir/l_l.glyph
@@ -34,6 +34,6 @@ SplineSet
  306.627929688 197.39453125 298.16015625 198.002929688 284 177.400390625 c 0
  224.9296875 91.4521484375 144 -14 84 -14 c 0
 EndSplineSet
-LCarets2: 1 264 
+LCarets2: 1 264
 Ligature2: "'dlig' optionale Ligaturen lookup 50 subtable" l l
 EndChar

--- a/SFD/EBGaramond08-Italic.sfdir/longs_b.glyph
+++ b/SFD/EBGaramond08-Italic.sfdir/longs_b.glyph
@@ -34,5 +34,5 @@ SplineSet
  464 366 363 177 363 105 c 0
 EndSplineSet
 Ligature2: "liga_standard subtable" longs b
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar

--- a/SFD/EBGaramond08-Italic.sfdir/longs_i.glyph
+++ b/SFD/EBGaramond08-Italic.sfdir/longs_i.glyph
@@ -36,5 +36,5 @@ SplineSet
  171.254882812 535.923828125 252 680 404 680 c 0
 EndSplineSet
 Ligature2: "liga_standard subtable" longs i
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar

--- a/SFD/EBGaramond08-Italic.sfdir/longs_l.glyph
+++ b/SFD/EBGaramond08-Italic.sfdir/longs_l.glyph
@@ -29,5 +29,5 @@ SplineSet
  459 680 483 648 483 609 c 0
 EndSplineSet
 Ligature2: "liga_standard subtable" longs l
-LCarets2: 1 260 
+LCarets2: 1 260
 EndChar

--- a/SFD/EBGaramond08-Italic.sfdir/longs_longs.glyph
+++ b/SFD/EBGaramond08-Italic.sfdir/longs_longs.glyph
@@ -36,5 +36,5 @@ EndSplineSet
 Substitution2: "Single Substitution lookup 64 subtable" longs_longs.short
 Substitution2: "Single Substitution lookup 63 subtable" longs_longs.short
 Ligature2: "liga_standard subtable" longs longs
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar

--- a/SFD/EBGaramond08-Italic.sfdir/longs_p.glyph
+++ b/SFD/EBGaramond08-Italic.sfdir/longs_p.glyph
@@ -46,6 +46,6 @@ SplineSet
  455.790039062 680 531 637 531 583 c 0
  531 527 495.795898438 453.684570312 492 431 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 Ligature2: "liga_standard subtable" longs p
 EndChar

--- a/SFD/EBGaramond08-Italic.sfdir/longs_s.glyph
+++ b/SFD/EBGaramond08-Italic.sfdir/longs_s.glyph
@@ -6,5 +6,5 @@ LayerCount: 2
 Fore
 Refer: 143 223 N 1 0 0 1 0 0 2
 Ligature2: "liga_standard subtable" longs s
-LCarets2: 1 170 
+LCarets2: 1 170
 EndChar

--- a/SFD/EBGaramond08-Italic.sfdir/longs_t.glyph
+++ b/SFD/EBGaramond08-Italic.sfdir/longs_t.glyph
@@ -37,5 +37,5 @@ SplineSet
  450.790039062 680 504 643 504 589 c 0
 EndSplineSet
 Ligature2: "liga_standard subtable" longs t
-LCarets2: 1 266 
+LCarets2: 1 266
 EndChar

--- a/SFD/EBGaramond08-Italic.sfdir/s_p.glyph
+++ b/SFD/EBGaramond08-Italic.sfdir/s_p.glyph
@@ -63,5 +63,5 @@ SplineSet
  560 380 522 365 516 341 c 2
 EndSplineSet
 Ligature2: "'hlig' Historic Ligatures lookup 48 subtable" s p
-LCarets2: 1 2 
+LCarets2: 1 2
 EndChar

--- a/SFD/EBGaramond08-Italic.sfdir/u_s.glyph
+++ b/SFD/EBGaramond08-Italic.sfdir/u_s.glyph
@@ -43,5 +43,5 @@ SplineSet
 EndSplineSet
 Ligature2: "Ligature Substitution lookup 58 subtable" u s
 Ligature2: "Ligature Substitution lookup 54 subtable" u s
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar

--- a/SFD/EBGaramond08-Italic.sfdir/uni00AD.glyph
+++ b/SFD/EBGaramond08-Italic.sfdir/uni00AD.glyph
@@ -1,0 +1,16 @@
+StartChar: uni00AD
+Encoding: 2117 173 2135
+Width: 386
+Flags: HW
+LayerCount: 2
+Fore
+SplineSet
+320 271 m 2
+ 334 272 351 266 351 243 c 0
+ 351 220 341 195 318 194 c 2
+ 99 176 l 2
+ 65 173 45 175 45 195 c 0
+ 45 214 56 249 82 252 c 2
+ 320 271 l 2
+EndSplineSet
+EndChar

--- a/SFD/EBGaramond08-Italic.sfdir/uniFB01.glyph
+++ b/SFD/EBGaramond08-Italic.sfdir/uniFB01.glyph
@@ -7,5 +7,5 @@ Fore
 Refer: 391 -1 N 1 0 0 1 0 0 2
 Ligature2: "liga_standard subtable" f.DEU i
 Ligature2: "liga_standard subtable" f i
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar

--- a/SFD/EBGaramond08-Italic.sfdir/uniFB03.glyph
+++ b/SFD/EBGaramond08-Italic.sfdir/uniFB03.glyph
@@ -9,5 +9,5 @@ Ligature2: "liga_standard subtable" f.DEU f.DEU i
 Ligature2: "liga_standard subtable" f.DEU f i
 Ligature2: "liga_standard subtable" f f.DEU i
 Ligature2: "liga_standard subtable" f f i
-LCarets2: 2 0 0 
+LCarets2: 2 0 0
 EndChar

--- a/SFD/EBGaramond08-Italic.sfdir/zero.glyph
+++ b/SFD/EBGaramond08-Italic.sfdir/zero.glyph
@@ -1,7 +1,7 @@
 StartChar: zero
 Encoding: 16 48 17
 Width: 469
-Flags: HMWO
+Flags: HMW
 LayerCount: 2
 Fore
 SplineSet

--- a/SFD/EBGaramond08-Regular.sfdir/_Ldot.glyph
+++ b/SFD/EBGaramond08-Regular.sfdir/_Ldot.glyph
@@ -8,5 +8,5 @@ Fore
 Refer: 745 183 S 1 0 0 1 245 -74 2
 Refer: 44 76 N 1 0 0 1 0 0 3
 Substitution2: "c2sc subtable" Ldot.sc
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar

--- a/SFD/EBGaramond08-Regular.sfdir/_T_h.glyph
+++ b/SFD/EBGaramond08-Regular.sfdir/_T_h.glyph
@@ -65,5 +65,5 @@ SplineSet
 EndSplineSet
 Validated: 1
 Ligature2: "Th_lig subtable" T h
-LCarets2: 1 508 
+LCarets2: 1 508
 EndChar

--- a/SFD/EBGaramond08-Regular.sfdir/ae.glyph
+++ b/SFD/EBGaramond08-Regular.sfdir/ae.glyph
@@ -52,5 +52,5 @@ EndSplineSet
 Validated: 1
 Substitution2: "Smallcaps1 subtable" ae.sc
 Ligature2: "LATliga subtable" a e
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar

--- a/SFD/EBGaramond08-Regular.sfdir/c_t.glyph
+++ b/SFD/EBGaramond08-Regular.sfdir/c_t.glyph
@@ -46,5 +46,5 @@ SplineSet
 EndSplineSet
 Validated: 33
 Ligature2: "'hlig' Historic Ligatures lookup 62 subtable" c t
-LCarets2: 1 355 
+LCarets2: 1 355
 EndChar

--- a/SFD/EBGaramond08-Regular.sfdir/f_f.glyph
+++ b/SFD/EBGaramond08-Regular.sfdir/f_f.glyph
@@ -10,5 +10,5 @@ Validated: 32769
 Substitution2: "Single Substitution lookup 71 subtable" f_f.short
 Ligature2: "liga_standard subtable" f.DEU f.DEU
 Ligature2: "liga_standard subtable" f f
-LCarets2: 1 262 
+LCarets2: 1 262
 EndChar

--- a/SFD/EBGaramond08-Regular.sfdir/f_f_i.glyph
+++ b/SFD/EBGaramond08-Regular.sfdir/f_f_i.glyph
@@ -11,5 +11,5 @@ Ligature2: "liga_standard subtable" f.DEU f.DEU i
 Ligature2: "liga_standard subtable" f.DEU f i
 Ligature2: "liga_standard subtable" f f.DEU i
 Ligature2: "liga_standard subtable" f f i
-LCarets2: 2 267 522 
+LCarets2: 2 267 522
 EndChar

--- a/SFD/EBGaramond08-Regular.sfdir/f_f_l.glyph
+++ b/SFD/EBGaramond08-Regular.sfdir/f_f_l.glyph
@@ -8,5 +8,5 @@ Fore
 Refer: 199 64260 N 1 0 0 1 0 0 2
 Validated: 32769
 Ligature2: "liga_standard subtable" f f l
-LCarets2: 2 269 541 
+LCarets2: 2 269 541
 EndChar

--- a/SFD/EBGaramond08-Regular.sfdir/f_i.glyph
+++ b/SFD/EBGaramond08-Regular.sfdir/f_i.glyph
@@ -9,5 +9,5 @@ Refer: 196 64257 N 1 0 0 1 0 0 2
 Validated: 32769
 Ligature2: "liga_standard subtable" f.DEU i
 Ligature2: "liga_standard subtable" f i
-LCarets2: 1 273 
+LCarets2: 1 273
 EndChar

--- a/SFD/EBGaramond08-Regular.sfdir/f_l.glyph
+++ b/SFD/EBGaramond08-Regular.sfdir/f_l.glyph
@@ -9,5 +9,5 @@ Refer: 197 64258 N 1 0 0 1 0 0 2
 Validated: 32769
 Ligature2: "liga_standard subtable" f.DEU l
 Ligature2: "liga_standard subtable" f l
-LCarets2: 1 279 
+LCarets2: 1 279
 EndChar

--- a/SFD/EBGaramond08-Regular.sfdir/font.props
+++ b/SFD/EBGaramond08-Regular.sfdir/font.props
@@ -1,4 +1,4 @@
-SplineFontDB: 3.0
+SplineFontDB: 3.2
 FontName: EBGaramond08-Regular
 FullName: EB Garamond 08 Regular
 FamilyName: EB Garamond 08
@@ -10,17 +10,18 @@ UnderlinePosition: -66
 UnderlineWidth: 70
 Ascent: 726
 Descent: 274
+InvalidEm: 0
 sfntRevision: 0x00010000
 LayerCount: 2
-Layer: 0 0 "Back"  1
-Layer: 1 0 "Zeichenebene"  0
+Layer: 0 0 "Back" 1
+Layer: 1 0 "Zeichenebene" 0
 XUID: [1021 660 827469224 13483894]
 FSType: 0
 OS2Version: 3
 OS2_WeightWidthSlopeOnly: 0
 OS2_UseTypoMetrics: 1
 CreationTime: 1339019456
-ModificationTime: 1396820558
+ModificationTime: 1614046920
 PfmFamily: 17
 TTFWeight: 400
 TTFWidth: 5
@@ -54,126 +55,126 @@ OS2FamilyClass: 258
 OS2Vendor: 'PfEd'
 OS2CodePages: 20000111.41000000
 OS2UnicodeRanges: 800000a7.5000004a.00000000.00000000
-Lookup: 1 0 0 "loclDEU"  {"loclDEU subtable"  } ['locl' ('latn' <'DEU ' > ) ]
-Lookup: 1 0 0 "loclTRK"  {"loclTRK subtable"  } ['locl' ('latn' <'TRK ' 'AZE ' 'CRT ' > ) ]
-Lookup: 6 0 0 "loclCAT"  {"loclCAT contextual 0"  "loclCAT contextual 1"  } ['locl' ('latn' <'CAT ' > ) ]
-Lookup: 1 0 0 "Single Substitution lookup 3"  {"Single Substitution lookup 3 subtable"  } []
-Lookup: 1 0 0 "Single Substitution lookup 4"  {"Single Substitution lookup 4 subtable"  } []
-Lookup: 1 0 0 "loclSRB"  {"loclSRB subtable"  } ['locl' ('cyrl' <'SRB ' 'MKD ' > ) ]
-Lookup: 1 0 0 "loclLAT"  {"loclLAT subtable"  } ['locl' ('latn' <'LAT ' > ) ]
-Lookup: 4 0 0 "LATliga"  {"LATliga subtable"  } []
-Lookup: 1 0 0 "'case' Case-Sensitive Forms lookup 8"  {"'case' Case-Sensitive Forms lookup 8 subtable"  } ['case' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
-Lookup: 2 0 0 "CCMP_Precomp"  {"CCMP_Precomp subtable"  } ['c2sc' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) 'smcp' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) 'cv81' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) 'cv80' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) 'ss20' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
-Lookup: 6 0 0 "CCMP_contextual"  {"CCMP_contextual contextual 0"  "CCMP_contextual contextual 1"  "CCMP_contextual contextual 2"  } ['ccmp' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
-Lookup: 1 0 0 "Single Substitution lookup 11"  {"Single Substitution lookup 11 subtable"  } []
-Lookup: 1 0 0 "Single Substitution lookup 12"  {"Single Substitution lookup 12 subtable"  } []
-Lookup: 1 0 0 "Single Substitution lookup 13"  {"Single Substitution lookup 13 subtable"  } []
-Lookup: 6 0 0 "CCMP_stacking1"  {"CCMP_stacking1 subtable"  } ['ccmp' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
-Lookup: 1 0 0 "Single Substitution lookup 15"  {"Single Substitution lookup 15 subtable"  } []
-Lookup: 6 0 0 "CCMP_stacking2"  {"CCMP_stacking2 subtable"  } ['ccmp' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
-Lookup: 1 0 0 "Single Substitution lookup 17"  {"Single Substitution lookup 17 subtable"  } []
-Lookup: 6 0 0 "CCMP_stackgrk1"  {"CCMP_stackgrk1 contextual 0"  "CCMP_stackgrk1 contextual 1"  "CCMP_stackgrk1 contextual 2"  "CCMP_stackgrk1 contextual 3"  } ['ccmp' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
-Lookup: 1 0 0 "Single Substitution lookup 19"  {"Single Substitution lookup 19 subtable"  } []
-Lookup: 1 0 0 "Single Substitution lookup 20"  {"Single Substitution lookup 20 subtable"  } []
-Lookup: 1 0 0 "Single Substitution lookup 21"  {"Single Substitution lookup 21 subtable"  } []
-Lookup: 1 0 0 "Single Substitution lookup 22"  {"Single Substitution lookup 22 subtable"  } []
-Lookup: 6 0 0 "CCMP_stackgrk2"  {"CCMP_stackgrk2 subtable"  } ['ccmp' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
-Lookup: 1 0 0 "Single Substitution lookup 24"  {"Single Substitution lookup 24 subtable"  } []
-Lookup: 1 0 0 "subs"  {"subs subtable" ("inferior" ) } ['dnom' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) 'subs' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
-Lookup: 1 0 0 "ordn"  {"ordn subtable"  } ['numr' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) 'ordn' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
-Lookup: 1 0 0 "sinf"  {"sinf subtable"  } ['sinf' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
-Lookup: 1 0 0 "sups"  {"sups subtable" ("superior" ) } ['sups' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
-Lookup: 1 0 0 "frac_slash"  {"frac_slash subtable"  } ['frac' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
-Lookup: 6 0 0 "frac"  {"frac contextual 0"  "frac contextual 1"  } ['frac' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
-Lookup: 1 0 0 "Single Substitution lookup 31"  {"Single Substitution lookup 31 subtable"  } []
-Lookup: 1 0 0 "Single Substitution lookup 32"  {"Single Substitution lookup 32 subtable"  } []
-Lookup: 1 0 0 "'lnum' Lining Figures lookup 33"  {"'lnum' Lining Figures lookup 33 subtable"  } ['lnum' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
-Lookup: 1 0 0 "'onum' Minuskelziffern lookup 34"  {"'onum' Minuskelziffern lookup 34 subtable" ("oldstyle" ) } ['onum' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
-Lookup: 1 0 0 "'tnum' Tabular Numbers lookup 35"  {"'tnum' Tabular Numbers lookup 35 subtable"  } ['tnum' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
-Lookup: 1 0 0 "'pnum' Proportionalziffern lookup 36"  {"'pnum' Proportionalziffern lookup 36 subtable"  } ['pnum' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
-Lookup: 1 0 0 "cyrillic_DLLj"  {"cyrillic_DLLj subtable"  } ['ss01' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
-Lookup: 6 0 0 "historic_u"  {"historic_u contextual 0"  "historic_u contextual 1"  "historic_u contextual 2"  "historic_u contextual 3"  "historic_u contextual 4"  } ['ss02' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
-Lookup: 1 0 0 "Single Substitution lookup 39"  {"Single Substitution lookup 39 subtable"  } []
-Lookup: 1 0 0 "Single Substitution lookup 40"  {"Single Substitution lookup 40 subtable"  } []
-Lookup: 1 0 0 "Single Substitution lookup 41"  {"Single Substitution lookup 41 subtable"  } []
-Lookup: 1 0 0 "Single Substitution lookup 42"  {"Single Substitution lookup 42 subtable"  } []
-Lookup: 6 0 0 "longs_replacement"  {"longs_replacement subtable"  } ['cv01' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
-Lookup: 1 0 0 "Single Substitution lookup 44"  {"Single Substitution lookup 44 subtable"  } []
-Lookup: 1 0 0 "at_alternates"  {"at_alternates subtable"  } ['cv02' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
-Lookup: 1 0 0 "historic_j"  {"historic_j subtable"  } ['cv03' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
-Lookup: 6 0 0 "historic_apostrophe"  {"historic_apostrophe subtable"  } ['ss05' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
-Lookup: 1 0 0 "Single Substitution lookup 48"  {"Single Substitution lookup 48 subtable"  } []
-Lookup: 1 0 0 "guillemet_var"  {"guillemet_var subtable"  } ['cv06' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
-Lookup: 1 0 0 "one_variants"  {"one_variants subtable"  } ['cv11' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
-Lookup: 3 0 0 "alternate_a"  {"alternate_a subtable"  } ['cv21' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
-Lookup: 3 0 0 "alternate_g"  {"alternate_g subtable"  } ['cv27' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
-Lookup: 3 0 0 "germandbls_variants"  {"germandbls_variants subtable"  } ['cv47' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
-Lookup: 1 0 0 "AE_alt"  {"AE_alt subtable"  } ['cv48' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
-Lookup: 1 0 0 "perispomeni_alt"  {"perispomeni_alt subtable"  } ['cv80' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
-Lookup: 3 0 0 "prosgegrammeni_alt"  {"prosgegrammeni_alt subtable"  } ['cv81' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
-Lookup: 1 0 0 "Smallcaps1"  {"Smallcaps1 subtable"  } ['smcp' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
-Lookup: 1 0 0 "c2sc"  {"c2sc subtable"  } ['c2sc' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
-Lookup: 6 0 0 "Smallcaps2"  {"Smallcaps2 contextual 0"  "Smallcaps2 contextual 1"  } ['c2sc' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) 'smcp' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
-Lookup: 1 0 0 "Single Substitution lookup 60"  {"Single Substitution lookup 60 subtable"  } []
-Lookup: 1 0 0 "Single Substitution lookup 61"  {"Single Substitution lookup 61 subtable"  } []
-Lookup: 4 0 0 "'hlig' Historic Ligatures lookup 62"  {"'hlig' Historic Ligatures lookup 62 subtable"  } ['hlig' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
-Lookup: 4 0 1 "liga_standard"  {"liga_standard subtable"  } ['liga' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
-Lookup: 4 0 0 "Th_lig"  {"Th_lig subtable"  } ['dlig' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
-Lookup: 6 0 0 "Q_alts"  {"Q_alts contextual 0"  "Q_alts contextual 1"  "Q_alts contextual 2"  "Q_alts contextual 3"  } ['calt' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
-Lookup: 1 0 0 "Single Substitution lookup 66"  {"Single Substitution lookup 66 subtable"  } []
-Lookup: 1 0 0 "Single Substitution lookup 67"  {"Single Substitution lookup 67 subtable"  } []
-Lookup: 1 0 0 "Single Substitution lookup 68"  {"Single Substitution lookup 68 subtable"  } []
-Lookup: 1 0 0 "Single Substitution lookup 69"  {"Single Substitution lookup 69 subtable"  } []
-Lookup: 6 0 0 "f_long"  {"f_long contextual 0"  "f_long contextual 1"  } []
-Lookup: 1 0 0 "Single Substitution lookup 71"  {"Single Substitution lookup 71 subtable"  } []
-Lookup: 1 0 0 "Single Substitution lookup 72"  {"Single Substitution lookup 72 subtable"  } []
-Lookup: 6 0 0 "caltLAT"  {"caltLAT subtable"  } ['calt' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
-Lookup: 1 0 0 "Single Substitution lookup 74"  {"Single Substitution lookup 74 subtable"  } []
-Lookup: 258 0 0 "kern"  {"kern kerning class 0"  "kern kerning class 1"  "kern kerning class 2"  } ['kern' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'DFLT' <'dflt' > ) ]
-Lookup: 264 0 0 "ckern1"  {"ckern1 contextual 0"  "ckern1 contextual 1"  "ckern1 contextual 2"  "ckern1 contextual 3"  "ckern1 contextual 4"  "ckern1 contextual 5"  "ckern1 contextual 6"  "ckern1 contextual 7"  "ckern1 contextual 8"  "ckern1 contextual 9"  "ckern1 contextual 10"  "ckern1 contextual 11"  "ckern1 contextual 12"  "ckern1 contextual 13"  "ckern1 contextual 14"  "ckern1 contextual 15"  "ckern1 contextual 16"  "ckern1 contextual 17"  "ckern1 contextual 18"  "ckern1 contextual 19"  "ckern1 contextual 20"  "ckern1 contextual 21"  "ckern1 contextual 22"  "ckern1 contextual 23"  "ckern1 contextual 24"  "ckern1 contextual 25"  "ckern1 contextual 26"  "ckern1 contextual 27"  "ckern1 contextual 28"  } ['kern' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'DFLT' <'dflt' > ) ]
-Lookup: 257 0 0 "Single Positioning lookup 2"  {"Single Positioning lookup 2 subtable"  } []
-Lookup: 257 0 0 "Single Positioning lookup 3"  {"Single Positioning lookup 3 subtable"  } []
-Lookup: 257 0 0 "Single Positioning lookup 4"  {"Single Positioning lookup 4 subtable"  } []
-Lookup: 257 0 0 "Single Positioning lookup 5"  {"Single Positioning lookup 5 subtable"  } []
-Lookup: 257 0 0 "Single Positioning lookup 6"  {"Single Positioning lookup 6 subtable"  } []
-Lookup: 257 0 0 "Single Positioning lookup 7"  {"Single Positioning lookup 7 subtable"  } []
-Lookup: 257 0 0 "Single Positioning lookup 8"  {"Single Positioning lookup 8 subtable"  } []
-Lookup: 257 0 0 "Single Positioning lookup 9"  {"Single Positioning lookup 9 subtable"  } []
-Lookup: 257 0 0 "Single Positioning lookup 10"  {"Single Positioning lookup 10 subtable"  } []
-Lookup: 257 0 0 "Single Positioning lookup 11"  {"Single Positioning lookup 11 subtable"  } []
-Lookup: 257 0 0 "Single Positioning lookup 12"  {"Single Positioning lookup 12 subtable"  } []
-Lookup: 257 0 0 "Single Positioning lookup 13"  {"Single Positioning lookup 13 subtable"  } []
-Lookup: 257 0 0 "Single Positioning lookup 14"  {"Single Positioning lookup 14 subtable"  } []
-Lookup: 257 0 0 "Single Positioning lookup 15"  {"Single Positioning lookup 15 subtable"  } []
-Lookup: 257 0 0 "Single Positioning lookup 16"  {"Single Positioning lookup 16 subtable"  } []
-Lookup: 257 0 0 "Single Positioning lookup 17"  {"Single Positioning lookup 17 subtable"  } []
-Lookup: 257 0 0 "Single Positioning lookup 18"  {"Single Positioning lookup 18 subtable"  } []
-Lookup: 257 0 0 "Single Positioning lookup 19"  {"Single Positioning lookup 19 subtable"  } []
-Lookup: 257 0 0 "Single Positioning lookup 20"  {"Single Positioning lookup 20 subtable"  } []
-Lookup: 257 0 0 "Single Positioning lookup 21"  {"Single Positioning lookup 21 subtable"  } []
-Lookup: 257 0 0 "Single Positioning lookup 22"  {"Single Positioning lookup 22 subtable"  } []
-Lookup: 257 0 0 "Single Positioning lookup 23"  {"Single Positioning lookup 23 subtable"  } []
-Lookup: 257 0 0 "Single Positioning lookup 24"  {"Single Positioning lookup 24 subtable"  } []
-Lookup: 257 0 0 "Single Positioning lookup 25"  {"Single Positioning lookup 25 subtable"  } []
-Lookup: 257 0 0 "Single Positioning lookup 26"  {"Single Positioning lookup 26 subtable"  } []
-Lookup: 257 0 0 "Single Positioning lookup 27"  {"Single Positioning lookup 27 subtable"  } []
-Lookup: 257 0 0 "Single Positioning lookup 28"  {"Single Positioning lookup 28 subtable"  } []
-Lookup: 257 0 0 "Single Positioning lookup 29"  {"Single Positioning lookup 29 subtable"  } []
-Lookup: 257 0 0 "Single Positioning lookup 30"  {"Single Positioning lookup 30 subtable"  } []
-Lookup: 264 0 0 "ckern2"  {"ckern2 contextual 0"  "ckern2 contextual 1"  } ['kern' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'DFLT' <'dflt' > ) ]
-Lookup: 257 0 0 "Single Positioning lookup 32"  {"Single Positioning lookup 32 subtable"  } []
-Lookup: 257 0 0 "Single Positioning lookup 33"  {"Single Positioning lookup 33 subtable"  } []
-Lookup: 260 0 0 "mark"  {"mark anchor 0"  "mark anchor 1"  "mark anchor 2"  "mark anchor 3"  } ['mark' ('DFLT' <'dflt' > 'latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > ) ]
-Lookup: 262 0 0 "mkmk"  {"mkmk subtable"  } ['mkmk' ('DFLT' <'dflt' > 'latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > ) ]
+Lookup: 1 0 0 "loclDEU" { "loclDEU subtable"  } ['locl' ('latn' <'DEU ' > ) ]
+Lookup: 1 0 0 "loclTRK" { "loclTRK subtable"  } ['locl' ('latn' <'TRK ' 'AZE ' 'CRT ' > ) ]
+Lookup: 6 0 0 "loclCAT" { "loclCAT contextual 0"  "loclCAT contextual 1"  } ['locl' ('latn' <'CAT ' > ) ]
+Lookup: 1 0 0 "Single Substitution lookup 3" { "Single Substitution lookup 3 subtable"  } []
+Lookup: 1 0 0 "Single Substitution lookup 4" { "Single Substitution lookup 4 subtable"  } []
+Lookup: 1 0 0 "loclSRB" { "loclSRB subtable"  } ['locl' ('cyrl' <'SRB ' 'MKD ' > ) ]
+Lookup: 1 0 0 "loclLAT" { "loclLAT subtable"  } ['locl' ('latn' <'LAT ' > ) ]
+Lookup: 4 0 0 "LATliga" { "LATliga subtable"  } []
+Lookup: 1 0 0 "'case' Case-Sensitive Forms lookup 8" { "'case' Case-Sensitive Forms lookup 8 subtable"  } ['case' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
+Lookup: 2 0 0 "CCMP_Precomp" { "CCMP_Precomp subtable"  } ['c2sc' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) 'smcp' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) 'cv81' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) 'cv80' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) 'ss20' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
+Lookup: 6 0 0 "CCMP_contextual" { "CCMP_contextual contextual 0"  "CCMP_contextual contextual 1"  "CCMP_contextual contextual 2"  } ['ccmp' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
+Lookup: 1 0 0 "Single Substitution lookup 11" { "Single Substitution lookup 11 subtable"  } []
+Lookup: 1 0 0 "Single Substitution lookup 12" { "Single Substitution lookup 12 subtable"  } []
+Lookup: 1 0 0 "Single Substitution lookup 13" { "Single Substitution lookup 13 subtable"  } []
+Lookup: 6 0 0 "CCMP_stacking1" { "CCMP_stacking1 subtable"  } ['ccmp' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
+Lookup: 1 0 0 "Single Substitution lookup 15" { "Single Substitution lookup 15 subtable"  } []
+Lookup: 6 0 0 "CCMP_stacking2" { "CCMP_stacking2 subtable"  } ['ccmp' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
+Lookup: 1 0 0 "Single Substitution lookup 17" { "Single Substitution lookup 17 subtable"  } []
+Lookup: 6 0 0 "CCMP_stackgrk1" { "CCMP_stackgrk1 contextual 0"  "CCMP_stackgrk1 contextual 1"  "CCMP_stackgrk1 contextual 2"  "CCMP_stackgrk1 contextual 3"  } ['ccmp' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
+Lookup: 1 0 0 "Single Substitution lookup 19" { "Single Substitution lookup 19 subtable"  } []
+Lookup: 1 0 0 "Single Substitution lookup 20" { "Single Substitution lookup 20 subtable"  } []
+Lookup: 1 0 0 "Single Substitution lookup 21" { "Single Substitution lookup 21 subtable"  } []
+Lookup: 1 0 0 "Single Substitution lookup 22" { "Single Substitution lookup 22 subtable"  } []
+Lookup: 6 0 0 "CCMP_stackgrk2" { "CCMP_stackgrk2 subtable"  } ['ccmp' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
+Lookup: 1 0 0 "Single Substitution lookup 24" { "Single Substitution lookup 24 subtable"  } []
+Lookup: 1 0 0 "subs" { "subs subtable" ("inferior") } ['dnom' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) 'subs' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
+Lookup: 1 0 0 "ordn" { "ordn subtable"  } ['numr' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) 'ordn' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
+Lookup: 1 0 0 "sinf" { "sinf subtable"  } ['sinf' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
+Lookup: 1 0 0 "sups" { "sups subtable" ("superior") } ['sups' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
+Lookup: 1 0 0 "frac_slash" { "frac_slash subtable"  } ['frac' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
+Lookup: 6 0 0 "frac" { "frac contextual 0"  "frac contextual 1"  } ['frac' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
+Lookup: 1 0 0 "Single Substitution lookup 31" { "Single Substitution lookup 31 subtable"  } []
+Lookup: 1 0 0 "Single Substitution lookup 32" { "Single Substitution lookup 32 subtable"  } []
+Lookup: 1 0 0 "'lnum' Lining Figures lookup 33" { "'lnum' Lining Figures lookup 33 subtable"  } ['lnum' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
+Lookup: 1 0 0 "'onum' Minuskelziffern lookup 34" { "'onum' Minuskelziffern lookup 34 subtable" ("oldstyle") } ['onum' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
+Lookup: 1 0 0 "'tnum' Tabular Numbers lookup 35" { "'tnum' Tabular Numbers lookup 35 subtable"  } ['tnum' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
+Lookup: 1 0 0 "'pnum' Proportionalziffern lookup 36" { "'pnum' Proportionalziffern lookup 36 subtable"  } ['pnum' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
+Lookup: 1 0 0 "cyrillic_DLLj" { "cyrillic_DLLj subtable"  } ['ss01' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
+Lookup: 6 0 0 "historic_u" { "historic_u contextual 0"  "historic_u contextual 1"  "historic_u contextual 2"  "historic_u contextual 3"  "historic_u contextual 4"  } ['ss02' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
+Lookup: 1 0 0 "Single Substitution lookup 39" { "Single Substitution lookup 39 subtable"  } []
+Lookup: 1 0 0 "Single Substitution lookup 40" { "Single Substitution lookup 40 subtable"  } []
+Lookup: 1 0 0 "Single Substitution lookup 41" { "Single Substitution lookup 41 subtable"  } []
+Lookup: 1 0 0 "Single Substitution lookup 42" { "Single Substitution lookup 42 subtable"  } []
+Lookup: 6 0 0 "longs_replacement" { "longs_replacement subtable"  } ['cv01' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
+Lookup: 1 0 0 "Single Substitution lookup 44" { "Single Substitution lookup 44 subtable"  } []
+Lookup: 1 0 0 "at_alternates" { "at_alternates subtable"  } ['cv02' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
+Lookup: 1 0 0 "historic_j" { "historic_j subtable"  } ['cv03' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
+Lookup: 6 0 0 "historic_apostrophe" { "historic_apostrophe subtable"  } ['ss05' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
+Lookup: 1 0 0 "Single Substitution lookup 48" { "Single Substitution lookup 48 subtable"  } []
+Lookup: 1 0 0 "guillemet_var" { "guillemet_var subtable"  } ['cv06' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
+Lookup: 1 0 0 "one_variants" { "one_variants subtable"  } ['cv11' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
+Lookup: 3 0 0 "alternate_a" { "alternate_a subtable"  } ['cv21' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
+Lookup: 3 0 0 "alternate_g" { "alternate_g subtable"  } ['cv27' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
+Lookup: 3 0 0 "germandbls_variants" { "germandbls_variants subtable"  } ['cv47' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
+Lookup: 1 0 0 "AE_alt" { "AE_alt subtable"  } ['cv48' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
+Lookup: 1 0 0 "perispomeni_alt" { "perispomeni_alt subtable"  } ['cv80' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
+Lookup: 3 0 0 "prosgegrammeni_alt" { "prosgegrammeni_alt subtable"  } ['cv81' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
+Lookup: 1 0 0 "Smallcaps1" { "Smallcaps1 subtable"  } ['smcp' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
+Lookup: 1 0 0 "c2sc" { "c2sc subtable"  } ['c2sc' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
+Lookup: 6 0 0 "Smallcaps2" { "Smallcaps2 contextual 0"  "Smallcaps2 contextual 1"  } ['c2sc' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) 'smcp' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
+Lookup: 1 0 0 "Single Substitution lookup 60" { "Single Substitution lookup 60 subtable"  } []
+Lookup: 1 0 0 "Single Substitution lookup 61" { "Single Substitution lookup 61 subtable"  } []
+Lookup: 4 0 0 "'hlig' Historic Ligatures lookup 62" { "'hlig' Historic Ligatures lookup 62 subtable"  } ['hlig' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
+Lookup: 4 0 1 "liga_standard" { "liga_standard subtable"  } ['liga' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
+Lookup: 4 0 0 "Th_lig" { "Th_lig subtable"  } ['dlig' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
+Lookup: 6 0 0 "Q_alts" { "Q_alts contextual 0"  "Q_alts contextual 1"  "Q_alts contextual 2"  "Q_alts contextual 3"  } ['calt' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
+Lookup: 1 0 0 "Single Substitution lookup 66" { "Single Substitution lookup 66 subtable"  } []
+Lookup: 1 0 0 "Single Substitution lookup 67" { "Single Substitution lookup 67 subtable"  } []
+Lookup: 1 0 0 "Single Substitution lookup 68" { "Single Substitution lookup 68 subtable"  } []
+Lookup: 1 0 0 "Single Substitution lookup 69" { "Single Substitution lookup 69 subtable"  } []
+Lookup: 6 0 0 "f_long" { "f_long contextual 0"  "f_long contextual 1"  } []
+Lookup: 1 0 0 "Single Substitution lookup 71" { "Single Substitution lookup 71 subtable"  } []
+Lookup: 1 0 0 "Single Substitution lookup 72" { "Single Substitution lookup 72 subtable"  } []
+Lookup: 6 0 0 "caltLAT" { "caltLAT subtable"  } ['calt' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'grek' <'dflt' > 'cyrl' <'dflt' 'SRB ' 'MKD ' > 'DFLT' <'dflt' > ) ]
+Lookup: 1 0 0 "Single Substitution lookup 74" { "Single Substitution lookup 74 subtable"  } []
+Lookup: 258 0 0 "kern" { "kern kerning class 0"  "kern kerning class 1"  "kern kerning class 2"  } ['kern' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'DFLT' <'dflt' > ) ]
+Lookup: 264 0 0 "ckern1" { "ckern1 contextual 0"  "ckern1 contextual 1"  "ckern1 contextual 2"  "ckern1 contextual 3"  "ckern1 contextual 4"  "ckern1 contextual 5"  "ckern1 contextual 6"  "ckern1 contextual 7"  "ckern1 contextual 8"  "ckern1 contextual 9"  "ckern1 contextual 10"  "ckern1 contextual 11"  "ckern1 contextual 12"  "ckern1 contextual 13"  "ckern1 contextual 14"  "ckern1 contextual 15"  "ckern1 contextual 16"  "ckern1 contextual 17"  "ckern1 contextual 18"  "ckern1 contextual 19"  "ckern1 contextual 20"  "ckern1 contextual 21"  "ckern1 contextual 22"  "ckern1 contextual 23"  "ckern1 contextual 24"  "ckern1 contextual 25"  "ckern1 contextual 26"  "ckern1 contextual 27"  "ckern1 contextual 28"  } ['kern' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'DFLT' <'dflt' > ) ]
+Lookup: 257 0 0 "Single Positioning lookup 2" { "Single Positioning lookup 2 subtable"  } []
+Lookup: 257 0 0 "Single Positioning lookup 3" { "Single Positioning lookup 3 subtable"  } []
+Lookup: 257 0 0 "Single Positioning lookup 4" { "Single Positioning lookup 4 subtable"  } []
+Lookup: 257 0 0 "Single Positioning lookup 5" { "Single Positioning lookup 5 subtable"  } []
+Lookup: 257 0 0 "Single Positioning lookup 6" { "Single Positioning lookup 6 subtable"  } []
+Lookup: 257 0 0 "Single Positioning lookup 7" { "Single Positioning lookup 7 subtable"  } []
+Lookup: 257 0 0 "Single Positioning lookup 8" { "Single Positioning lookup 8 subtable"  } []
+Lookup: 257 0 0 "Single Positioning lookup 9" { "Single Positioning lookup 9 subtable"  } []
+Lookup: 257 0 0 "Single Positioning lookup 10" { "Single Positioning lookup 10 subtable"  } []
+Lookup: 257 0 0 "Single Positioning lookup 11" { "Single Positioning lookup 11 subtable"  } []
+Lookup: 257 0 0 "Single Positioning lookup 12" { "Single Positioning lookup 12 subtable"  } []
+Lookup: 257 0 0 "Single Positioning lookup 13" { "Single Positioning lookup 13 subtable"  } []
+Lookup: 257 0 0 "Single Positioning lookup 14" { "Single Positioning lookup 14 subtable"  } []
+Lookup: 257 0 0 "Single Positioning lookup 15" { "Single Positioning lookup 15 subtable"  } []
+Lookup: 257 0 0 "Single Positioning lookup 16" { "Single Positioning lookup 16 subtable"  } []
+Lookup: 257 0 0 "Single Positioning lookup 17" { "Single Positioning lookup 17 subtable"  } []
+Lookup: 257 0 0 "Single Positioning lookup 18" { "Single Positioning lookup 18 subtable"  } []
+Lookup: 257 0 0 "Single Positioning lookup 19" { "Single Positioning lookup 19 subtable"  } []
+Lookup: 257 0 0 "Single Positioning lookup 20" { "Single Positioning lookup 20 subtable"  } []
+Lookup: 257 0 0 "Single Positioning lookup 21" { "Single Positioning lookup 21 subtable"  } []
+Lookup: 257 0 0 "Single Positioning lookup 22" { "Single Positioning lookup 22 subtable"  } []
+Lookup: 257 0 0 "Single Positioning lookup 23" { "Single Positioning lookup 23 subtable"  } []
+Lookup: 257 0 0 "Single Positioning lookup 24" { "Single Positioning lookup 24 subtable"  } []
+Lookup: 257 0 0 "Single Positioning lookup 25" { "Single Positioning lookup 25 subtable"  } []
+Lookup: 257 0 0 "Single Positioning lookup 26" { "Single Positioning lookup 26 subtable"  } []
+Lookup: 257 0 0 "Single Positioning lookup 27" { "Single Positioning lookup 27 subtable"  } []
+Lookup: 257 0 0 "Single Positioning lookup 28" { "Single Positioning lookup 28 subtable"  } []
+Lookup: 257 0 0 "Single Positioning lookup 29" { "Single Positioning lookup 29 subtable"  } []
+Lookup: 257 0 0 "Single Positioning lookup 30" { "Single Positioning lookup 30 subtable"  } []
+Lookup: 264 0 0 "ckern2" { "ckern2 contextual 0"  "ckern2 contextual 1"  } ['kern' ('latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > 'DFLT' <'dflt' > ) ]
+Lookup: 257 0 0 "Single Positioning lookup 32" { "Single Positioning lookup 32 subtable"  } []
+Lookup: 257 0 0 "Single Positioning lookup 33" { "Single Positioning lookup 33 subtable"  } []
+Lookup: 260 0 0 "mark" { "mark anchor 0"  "mark anchor 1"  "mark anchor 2"  "mark anchor 3"  } ['mark' ('DFLT' <'dflt' > 'latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > ) ]
+Lookup: 262 0 0 "mkmk" { "mkmk subtable"  } ['mkmk' ('DFLT' <'dflt' > 'latn' <'dflt' 'DEU ' 'TRK ' 'AZE ' 'CRT ' 'CAT ' 'LAT ' > ) ]
 MarkAttachClasses: 1
 DEI: 91125
-KernClass2: 4 2 "kern kerning class 2" 
+KernClass2: 4 2 "kern kerning class 2"
  5 Gamma
  3 Tau
  68 Upsilon Upsilondieresis Upsilontonos uni1F59 uni1F5B uni1F5D uni1F5F
  114 alpha chi epsilon eta gamma iota kappa mu nu omega omicron pi rho sigma sigma1 tau uni1FB3 uni1FC3 uni1FF3 upsilon
  0 {} 0 {} 0 {} -100 {} 0 {} -90 {} 0 {} -50 {}
-KernClass2: 3 9 "kern kerning class 1" 
+KernClass2: 3 9 "kern kerning class 1"
  15 uni0413 uni0490
  7 uni0422
  79 uni0430 uni0435 uni0437 uni043E uni0441 uni044D uni044F uni0454 uni0455 uni04E9
@@ -185,7 +186,7 @@ KernClass2: 3 9 "kern kerning class 1"
  7 uni0444
  7 uni0447
  0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -130 {} -100 {} -140 {} -105 {} -130 {} -115 {} -70 {} -115 {} 0 {} -125 {} -95 {} -135 {} -100 {} -130 {} -110 {} -65 {} -110 {}
-KernClass2: 15 15 "kern kerning class 0" 
+KernClass2: 15 15 "kern kerning class 0"
  81 A Aacute Abreve Acircumflex Adieresis Agrave Amacron Aogonek Aring Atilde uni0245
  9 A.sc a.sc
  86 E Eacute Ebreve Ecaron Ecircumflex Edieresis Edotaccent Egrave Emacron Eogonek uni1EBC
@@ -215,452 +216,452 @@ KernClass2: 15 15 "kern kerning class 0"
  3 eth
  8 dotlessi
  0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -40 {} -100 {} 0 {} 0 {} 0 {} 0 {} 0 {} -70 {} -60 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -75 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -10 {} 0 {} -20 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -10 {} 0 {} -20 {} -10 {} 0 {} -10 {} 0 {} -10 {} -20 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -50 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -10 {} 0 {} 0 {} -10 {} 0 {} -30 {} 0 {} -10 {} 0 {} 0 {} -60 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -60 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -35 {} 0 {} -20 {} 0 {} 0 {} -10 {} 0 {} -35 {} -20 {} 0 {} -100 {} 0 {} 0 {} 0 {} 0 {} -30 {} 0 {} 0 {} 0 {} 0 {} 0 {} -100 {} -30 {} 0 {} 0 {} 0 {} -75 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 100 {} 0 {} 0 {} 0 {} 0 {} 0 {} 100 {} 100 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -16 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -70 {} 0 {} 0 {} 0 {} -50 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -50 {} 0 {} 0 {}
-ChainSub2: coverage "caltLAT subtable"  0 0 0 1
+ChainSub2: coverage "caltLAT subtable" 0 0 0 1
  1 1 0
   Coverage: 11 u.LAT v.LAT
   BCoverage: 1354 A B C D E F G H I J K L M N O P Q R S T U V W X Y Z Agrave Aacute Acircumflex Atilde Adieresis Aring AE Ccedilla Egrave Eacute Ecircumflex Edieresis Igrave Iacute Icircumflex Idieresis Eth Ntilde Ograve Oacute Ocircumflex Otilde Odieresis Oslash Ugrave Uacute Ucircumflex Udieresis Yacute Thorn Amacron Abreve Aogonek Cacute Ccircumflex Cdotaccent Ccaron Dcaron Dcroat Emacron Ebreve Edotaccent Eogonek Ecaron Gcircumflex Gbreve Gdotaccent uni0122 Hcircumflex Hbar Itilde Imacron Ibreve Iogonek Idotaccent IJ Jcircumflex uni0136 Lacute uni013B Lcaron Ldot Lslash Nacute uni0145 Ncaron Eng Omacron Obreve Ohungarumlaut OE Racute uni0156 Rcaron Sacute Scircumflex Scedilla Scaron uni0162 Tcaron Tbar Utilde Umacron Ubreve Uring Uhungarumlaut Uogonek Wcircumflex Ycircumflex Ydieresis Zacute Zdotaccent Zcaron Q.long U.LAT a b c d e f g h i j k l m n o p q r s t u v w x y z longs germandbls adieresis edieresis odieresis udieresis idieresis aacute eacute iacute oacute uacute agrave egrave igrave ograve ugrave atilde uni1EBD otilde utilde oe f.DEU f.long i.TRK u.LAT u.LATmedi v.LAT v.LATmedi longs.long f.long germandbls.alt f_f f_i f_l f_f_i f_f_l longs_t s_t longs_longs_l longs_longs_i longs_i longs_longs longs_l T_h c_h c_k longs_s c_t f_f.long t_t f_h f_k f_b f_t f_j longs_j longs_b longs_h longs_k longs_longs.long U.LAT u.LAT u.LATmedi v.LATmedi
  1
-  SeqLookup: 0 "Single Substitution lookup 74" 
+  SeqLookup: 0 "Single Substitution lookup 74"
 EndFPST
-ChainSub2: coverage "f_long contextual 1"  0 0 0 1
+ChainSub2: coverage "f_long contextual 1" 0 0 0 1
  1 0 1
   Coverage: 41 longs longs_longs uni1E9B uni1E9C uni1E9D
   FCoverage: 3415 b h i j k l agrave aacute acircumflex atilde adieresis aring egrave eacute ecircumflex edieresis igrave iacute icircumflex idieresis eth ntilde ograve oacute ocircumflex otilde odieresis ugrave uacute ucircumflex udieresis yacute thorn amacron abreve cacute ccircumflex ccaron emacron ebreve ecaron gcircumflex gbreve uni0123 hcircumflex hbar itilde imacron ibreve iogonek dotlessi ij jcircumflex uni0137 lacute uni013C lcaron ldot lslash nacute ncaron omacron obreve ohungarumlaut racute rcaron sacute scircumflex scaron utilde umacron ubreve uring uhungarumlaut wcircumflex ycircumflex ydieresis zacute zdotaccent zcaron uni1E03 uni1E05 uni1E07 uni1E15 uni1E17 uni1E1D uni1E1F uni1E23 uni1E25 uni1E27 uni1E29 uni1E2B uni1E2D uni1E2F uni1E31 uni1E33 uni1E35 uni1E37 uni1E39 uni1E3B uni1E3D uni1E4F uni1E51 uni1E65 uni1E67 uni1E6B uni1E7B uni1E8D uni1E96 uni1E97 uni1E9A uni1E9B uni1E9C uni1E9D uni1E9F uni1EA3 uni1EA5 uni1EA6 uni1EA7 uni1EA8 uni1EA9 uni1EAB uni1EAD uni1EAF uni1EB1 uni1EB3 uni1EB5 uni1EB7 uni1EBB uni1EC1 uni1EC5 uni1EC9 uni1ECB uni1ECF uni1ED3 uni1ED7 uni1EDD uni1EDF uni1EE7 uni1EEB uni1EED uni1EF3 uni1EF7 uni1EFB i.TRK exclam quotedbl dollar percent quotesingle parenleft parenright asterisk question bracketleft backslash bracketright braceleft bar braceright registered quoteleft quoteright quotedblleft quotedblright minute second uni2034 exclamdbl uni203D uni2047 uni2048 uni2049 exclam.ordn quotedbl.ordn numbersign.ordn dollar.ordn percent.ordn ampersand.ordn quotesingle.ordn parenleft.ordn parenright.ordn asterisk.ordn plus.ordn comma.ordn hyphen.ordn period.ordn slash.ordn zero.ordn one.ordn two.ordn three.ordn four.ordn five.ordn six.ordn seven.ordn eight.ordn nine.ordn colon.ordn semicolon.ordn less.ordn equal.ordn greater.ordn question.ordn at.ordn A.ordn B.ordn C.ordn D.ordn E.ordn F.ordn G.ordn H.ordn I.ordn J.ordn K.ordn L.ordn M.ordn N.ordn O.ordn P.ordn Q.ordn R.ordn S.ordn T.ordn U.ordn V.ordn W.ordn X.ordn Y.ordn Z.ordn bracketleft.ordn backslash.ordn bracketright.ordn asciicircum.ordn underscore.ordn grave.ordn a.ordn b.ordn c.ordn d.ordn e.ordn f.ordn g.ordn h.ordn i.ordn j.ordn k.ordn l.ordn m.ordn n.ordn o.ordn p.ordn q.ordn r.ordn s.ordn t.ordn u.ordn v.ordn w.ordn x.ordn y.ordn z.ordn braceleft.ordn bar.ordn braceright.ordn asciitilde.ordn brokenbar.ordn section.ordn paragraph.ordn egrave.ordn uni2016.ordn dagger.ordn daggerdbl.ordn f.ordn i.ordn exclam.sups quotedbl.sups numbersign.sups dollar.sups percent.sups ampersand.sups quotesingle.sups parenleft.sups parenright.sups asterisk.sups plus.sups comma.sups hyphen.sups period.sups slash.sups zero.sups one.sups two.sups three.sups four.sups five.sups six.sups seven.sups eight.sups nine.sups colon.sups semicolon.sups less.sups equal.sups greater.sups question.sups at.sups A.sups B.sups C.sups D.sups E.sups F.sups G.sups H.sups I.sups J.sups K.sups L.sups M.sups N.sups O.sups P.sups Q.sups R.sups S.sups T.sups U.sups V.sups W.sups X.sups Y.sups Z.sups bracketleft.sups backslash.sups bracketright.sups asciicircum.sups underscore.sups grave.sups a.sups b.sups c.sups d.sups e.sups f.sups g.sups h.sups i.sups j.sups k.sups l.sups m.sups n.sups o.sups p.sups q.sups r.sups s.sups t.sups u.sups v.sups w.sups x.sups y.sups z.sups braceleft.sups bar.sups braceright.sups asciitilde.sups brokenbar.sups section.sups paragraph.sups egrave.sups uni2016.sups dagger.sups daggerdbl.sups f.sups i.sups
  1
-  SeqLookup: 0 "Single Substitution lookup 72" 
+  SeqLookup: 0 "Single Substitution lookup 72"
 EndFPST
-ChainSub2: coverage "f_long contextual 0"  0 0 0 1
+ChainSub2: coverage "f_long contextual 0" 0 0 0 1
  1 0 1
   Coverage: 19 f f_f f.DEU uni1E1F
   FCoverage: 3153 b h i j k l agrave acircumflex adieresis aring egrave edieresis igrave iacute icircumflex idieresis eth ograve ugrave thorn germandbls abreve ccaron ebreve ecaron gbreve uni0123 hcircumflex hbar itilde imacron ibreve iogonek dotlessi ij jcircumflex uni0137 lacute uni013C lcaron ldot lslash ncaron obreve rcaron scircumflex scaron ubreve ydieresis zcaron longs uni1E03 uni1E05 uni1E07 uni1E15 uni1E17 uni1E1D uni1E1F uni1E23 uni1E25 uni1E27 uni1E29 uni1E2B uni1E2D uni1E2F uni1E31 uni1E33 uni1E35 uni1E37 uni1E39 uni1E3B uni1E3D uni1E4F uni1E51 uni1E65 uni1E67 uni1E6B uni1E7B uni1E8D uni1E96 uni1E97 uni1E9A uni1E9B uni1E9C uni1E9D uni1E9F uni1EA3 uni1EA5 uni1EA6 uni1EA7 uni1EA8 uni1EA9 uni1EAB uni1EAD uni1EAF uni1EB1 uni1EB3 uni1EB5 uni1EB7 uni1EBB uni1EC1 uni1EC5 uni1EC9 uni1ECB uni1ECF uni1ED3 uni1ED7 uni1EDD uni1EDF uni1EE7 uni1EEB uni1EED uni1EF3 uni1EF7 uni1EFB i.TRK exclam quotedbl dollar percent quotesingle parenleft parenright asterisk question bracketleft backslash bracketright braceleft bar braceright registered quoteleft quoteright quotedblleft quotedblright minute second uni2034 exclamdbl uni203D uni2047 uni2048 uni2049 exclam.ordn quotedbl.ordn numbersign.ordn dollar.ordn percent.ordn ampersand.ordn quotesingle.ordn parenleft.ordn parenright.ordn asterisk.ordn plus.ordn comma.ordn hyphen.ordn period.ordn slash.ordn zero.ordn one.ordn two.ordn three.ordn four.ordn five.ordn six.ordn seven.ordn eight.ordn nine.ordn colon.ordn semicolon.ordn less.ordn equal.ordn greater.ordn question.ordn at.ordn A.ordn B.ordn C.ordn D.ordn E.ordn F.ordn G.ordn H.ordn I.ordn J.ordn K.ordn L.ordn M.ordn N.ordn O.ordn P.ordn Q.ordn R.ordn S.ordn T.ordn U.ordn V.ordn W.ordn X.ordn Y.ordn Z.ordn bracketleft.ordn backslash.ordn bracketright.ordn asciicircum.ordn underscore.ordn grave.ordn a.ordn b.ordn c.ordn d.ordn e.ordn f.ordn g.ordn h.ordn i.ordn j.ordn k.ordn l.ordn m.ordn n.ordn o.ordn p.ordn q.ordn r.ordn s.ordn t.ordn u.ordn v.ordn w.ordn x.ordn y.ordn z.ordn braceleft.ordn bar.ordn braceright.ordn asciitilde.ordn brokenbar.ordn section.ordn paragraph.ordn egrave.ordn uni2016.ordn dagger.ordn daggerdbl.ordn f.ordn i.ordn exclam.sups quotedbl.sups numbersign.sups dollar.sups percent.sups ampersand.sups quotesingle.sups parenleft.sups parenright.sups asterisk.sups plus.sups comma.sups hyphen.sups period.sups slash.sups zero.sups one.sups two.sups three.sups four.sups five.sups six.sups seven.sups eight.sups nine.sups colon.sups semicolon.sups less.sups equal.sups greater.sups question.sups at.sups A.sups B.sups C.sups D.sups E.sups F.sups G.sups H.sups I.sups J.sups K.sups L.sups M.sups N.sups O.sups P.sups Q.sups R.sups S.sups T.sups U.sups V.sups W.sups X.sups Y.sups Z.sups bracketleft.sups backslash.sups bracketright.sups asciicircum.sups underscore.sups grave.sups a.sups b.sups c.sups d.sups e.sups f.sups g.sups h.sups i.sups j.sups k.sups l.sups m.sups n.sups o.sups p.sups q.sups r.sups s.sups t.sups u.sups v.sups w.sups x.sups y.sups z.sups braceleft.sups bar.sups braceright.sups asciitilde.sups brokenbar.sups section.sups paragraph.sups egrave.sups uni2016.sups dagger.sups daggerdbl.sups f.sups i.sups
  1
-  SeqLookup: 0 "Single Substitution lookup 71" 
+  SeqLookup: 0 "Single Substitution lookup 71"
 EndFPST
-ChainSub2: coverage "Q_alts contextual 3"  0 0 0 1
+ChainSub2: coverage "Q_alts contextual 3" 0 0 0 1
  1 0 1
   Coverage: 1 Q
   FCoverage: 52 J comma semicolon parenright bracketright braceright
  1
-  SeqLookup: 0 "Single Substitution lookup 69" 
+  SeqLookup: 0 "Single Substitution lookup 69"
 EndFPST
-ChainSub2: coverage "Q_alts contextual 2"  0 0 0 1
+ChainSub2: coverage "Q_alts contextual 2" 0 0 0 1
  1 0 1
   Coverage: 1 Q
   FCoverage: 7 g j p y
  1
-  SeqLookup: 0 "Single Substitution lookup 68" 
+  SeqLookup: 0 "Single Substitution lookup 68"
 EndFPST
-ChainSub2: coverage "Q_alts contextual 1"  0 0 0 1
+ChainSub2: coverage "Q_alts contextual 1" 0 0 0 1
  1 0 3
   Coverage: 1 Q
   FCoverage: 2041 A B C D E F G H I K L M N O P R S T U V W X Y Z a b c d e f h k m n o r s t u v w x z Agrave Aacute Acircumflex Atilde Adieresis Aring AE Egrave Eacute Ecircumflex Edieresis Igrave Iacute Icircumflex Idieresis Eth Ntilde Ograve Oacute Ocircumflex Otilde Odieresis Oslash Ugrave Uacute Ucircumflex Udieresis Yacute Thorn germandbls agrave aacute acircumflex atilde adieresis aring ae egrave eacute ecircumflex edieresis eth ntilde ograve oacute ocircumflex otilde odieresis oslash ugrave uacute ucircumflex udieresis Amacron amacron Abreve abreve Cacute cacute Ccircumflex ccircumflex Cdotaccent cdotaccent Ccaron ccaron Dcaron dcaron Dcroat dcroat Emacron emacron Ebreve ebreve Edotaccent edotaccent Ecaron ecaron Gcircumflex Gbreve Gdotaccent Hcircumflex hcircumflex Hbar hbar Itilde Imacron Ibreve Idotaccent kgreenlandic Lacute Lcaron Ldot Lslash Nacute nacute Ncaron ncaron napostrophe Omacron omacron Obreve obreve Ohungarumlaut ohungarumlaut OE oe Racute racute Rcaron rcaron Sacute sacute Scircumflex scircumflex Scaron scaron Tcaron tcaron Tbar tbar Utilde utilde Umacron umacron Ubreve ubreve Uring uring Uhungarumlaut uhungarumlaut Wcircumflex wcircumflex Ycircumflex Ydieresis Zacute zacute Zdotaccent zdotaccent Zcaron zcaron longs Ohorn ohorn Uhorn uhorn uni01C4 uni01C5 uni01C6 uni01CD uni01CE uni01CF uni01D1 uni01D2 uni01D3 uni01D4 uni01D5 uni01D6 uni01D7 uni01D8 uni01D9 uni01DA uni01DB uni01DC uni01DE uni01DF uni01E0 uni01E1 uni01E2 uni01E3 Gcaron uni01E8 uni01E9 uni01F1 uni01F2 uni01F3 uni01F4 uni01F8 uni01F9 Aringacute aringacute AEacute aeacute Oslashacute oslashacute uni0202 uni0203 uni0206 uni0207 uni020A uni020B uni020E uni020F uni0212 uni0213 uni0216 uni0217 uni021E uni021F uni0226 uni0227 uni022A uni022B uni022C uni022D uni022E uni022F uni0230 uni0231 uni0232 f.DEU u.LAT v.LATmedi f_f f_i f_l f_f_i f_f_l longs_t s_t f_f.long f.long f_h f_k f_b f_t longs_b longs_h longs_k longs.long longs_longs.long f_f_h f_f_k f_f_b f_f_t longs_longs_b longs_longs_h longs_longs_k longs_longs_t longs_s c_t germandbls.alt
   FCoverage: 2196 A B C D E F G H I K L M N O P R S T U V W X Y Z a b c d e f h k m n o r s t u v w x z Agrave Aacute Acircumflex Atilde Adieresis Aring AE Egrave Eacute Ecircumflex Edieresis Igrave Iacute Icircumflex Idieresis Eth Ntilde Ograve Oacute Ocircumflex Otilde Odieresis Oslash Ugrave Uacute Ucircumflex Udieresis Yacute Thorn germandbls agrave aacute acircumflex atilde adieresis aring ae egrave eacute ecircumflex edieresis eth ntilde ograve oacute ocircumflex otilde odieresis oslash ugrave uacute ucircumflex udieresis Amacron amacron Abreve abreve Cacute cacute Ccircumflex ccircumflex Cdotaccent cdotaccent Ccaron ccaron Dcaron dcaron Dcroat dcroat Emacron emacron Ebreve ebreve Edotaccent edotaccent Ecaron ecaron Gcircumflex Gbreve Gdotaccent Hcircumflex hcircumflex Hbar hbar Itilde Imacron Ibreve Idotaccent kgreenlandic Lacute Lcaron Ldot Lslash Nacute nacute Ncaron ncaron napostrophe Omacron omacron Obreve obreve Ohungarumlaut ohungarumlaut OE oe Racute racute Rcaron rcaron Sacute sacute Scircumflex scircumflex Scaron scaron Tcaron tcaron Tbar tbar Utilde utilde Umacron umacron Ubreve ubreve Uring uring Uhungarumlaut uhungarumlaut Wcircumflex wcircumflex Ycircumflex Ydieresis Zacute zacute Zdotaccent zdotaccent Zcaron zcaron longs Ohorn ohorn Uhorn uhorn uni01C4 uni01C5 uni01C6 uni01CD uni01CE uni01CF uni01D1 uni01D2 uni01D3 uni01D4 uni01D5 uni01D6 uni01D7 uni01D8 uni01D9 uni01DA uni01DB uni01DC uni01DE uni01DF uni01E0 uni01E1 uni01E2 uni01E3 Gcaron uni01E8 uni01E9 uni01F1 uni01F2 uni01F3 uni01F4 uni01F8 uni01F9 Aringacute aringacute AEacute aeacute Oslashacute oslashacute uni0202 uni0203 uni0206 uni0207 uni020A uni020B uni020E uni020F uni0212 uni0213 uni0216 uni0217 uni021E uni021F uni0226 uni0227 uni022A uni022B uni022C uni022D uni022E uni022F uni0230 uni0231 uni0232 f.DEU u.LAT v.LATmedi f_f f_i f_l f_f_i f_f_l longs_t s_t f_f.long f.long f_h f_k f_b f_t longs_b longs_h longs_k longs.long longs_longs.long f_f_h f_f_k f_f_b f_f_t longs_longs_b longs_longs_h longs_longs_k longs_longs_t longs_s c_t germandbls.alt i l igrave iacute icircumflex idieresis itilde imacron ibreve dotlessi lacute lcaron ldot lslash uni01D0 uni0209 uni020B i.TRK j.hist quoteleft quoteright
   FCoverage: 2209 A B C D E F G H I K L M N O P R S T U V W X Y Z a b c d e f h k m n o r s t u v w x z Agrave Aacute Acircumflex Atilde Adieresis Aring AE Egrave Eacute Ecircumflex Edieresis Igrave Iacute Icircumflex Idieresis Eth Ntilde Ograve Oacute Ocircumflex Otilde Odieresis Oslash Ugrave Uacute Ucircumflex Udieresis Yacute Thorn germandbls agrave aacute acircumflex atilde adieresis aring ae egrave eacute ecircumflex edieresis eth ntilde ograve oacute ocircumflex otilde odieresis oslash ugrave uacute ucircumflex udieresis Amacron amacron Abreve abreve Cacute cacute Ccircumflex ccircumflex Cdotaccent cdotaccent Ccaron ccaron Dcaron dcaron Dcroat dcroat Emacron emacron Ebreve ebreve Edotaccent edotaccent Ecaron ecaron Gcircumflex Gbreve Gdotaccent Hcircumflex hcircumflex Hbar hbar Itilde Imacron Ibreve Idotaccent kgreenlandic Lacute Lcaron Ldot Lslash Nacute nacute Ncaron ncaron napostrophe Omacron omacron Obreve obreve Ohungarumlaut ohungarumlaut OE oe Racute racute Rcaron rcaron Sacute sacute Scircumflex scircumflex Scaron scaron Tcaron tcaron Tbar tbar Utilde utilde Umacron umacron Ubreve ubreve Uring uring Uhungarumlaut uhungarumlaut Wcircumflex wcircumflex Ycircumflex Ydieresis Zacute zacute Zdotaccent zdotaccent Zcaron zcaron longs Ohorn ohorn Uhorn uhorn uni01C4 uni01C5 uni01C6 uni01CD uni01CE uni01CF uni01D1 uni01D2 uni01D3 uni01D4 uni01D5 uni01D6 uni01D7 uni01D8 uni01D9 uni01DA uni01DB uni01DC uni01DE uni01DF uni01E0 uni01E1 uni01E2 uni01E3 Gcaron uni01E8 uni01E9 uni01F1 uni01F2 uni01F3 uni01F4 uni01F8 uni01F9 Aringacute aringacute AEacute aeacute Oslashacute oslashacute uni0202 uni0203 uni0206 uni0207 uni020A uni020B uni020E uni020F uni0212 uni0213 uni0216 uni0217 uni021E uni021F uni0226 uni0227 uni022A uni022B uni022C uni022D uni022E uni022F uni0230 uni0231 uni0232 f.DEU u.LAT v.LATmedi f_f f_i f_l f_f_i f_f_l longs_t s_t f_f.long f.long f_h f_k f_b f_t longs_b longs_h longs_k longs.long longs_longs.long f_f_h f_f_k f_f_b f_f_t longs_longs_b longs_longs_h longs_longs_k longs_longs_t longs_s c_t germandbls.alt i l igrave iacute icircumflex idieresis itilde imacron ibreve dotlessi lacute lcaron ldot lslash uni01D0 uni0209 uni020B i.TRK j.hist q f_j longs_j f_f_j longs_longs_j
  1
-  SeqLookup: 0 "Single Substitution lookup 67" 
+  SeqLookup: 0 "Single Substitution lookup 67"
 EndFPST
-ChainSub2: coverage "Q_alts contextual 0"  0 0 0 1
+ChainSub2: coverage "Q_alts contextual 0" 0 0 0 1
  1 0 2
   Coverage: 1 Q
   FCoverage: 2041 A B C D E F G H I K L M N O P R S T U V W X Y Z a b c d e f h k m n o r s t u v w x z Agrave Aacute Acircumflex Atilde Adieresis Aring AE Egrave Eacute Ecircumflex Edieresis Igrave Iacute Icircumflex Idieresis Eth Ntilde Ograve Oacute Ocircumflex Otilde Odieresis Oslash Ugrave Uacute Ucircumflex Udieresis Yacute Thorn germandbls agrave aacute acircumflex atilde adieresis aring ae egrave eacute ecircumflex edieresis eth ntilde ograve oacute ocircumflex otilde odieresis oslash ugrave uacute ucircumflex udieresis Amacron amacron Abreve abreve Cacute cacute Ccircumflex ccircumflex Cdotaccent cdotaccent Ccaron ccaron Dcaron dcaron Dcroat dcroat Emacron emacron Ebreve ebreve Edotaccent edotaccent Ecaron ecaron Gcircumflex Gbreve Gdotaccent Hcircumflex hcircumflex Hbar hbar Itilde Imacron Ibreve Idotaccent kgreenlandic Lacute Lcaron Ldot Lslash Nacute nacute Ncaron ncaron napostrophe Omacron omacron Obreve obreve Ohungarumlaut ohungarumlaut OE oe Racute racute Rcaron rcaron Sacute sacute Scircumflex scircumflex Scaron scaron Tcaron tcaron Tbar tbar Utilde utilde Umacron umacron Ubreve ubreve Uring uring Uhungarumlaut uhungarumlaut Wcircumflex wcircumflex Ycircumflex Ydieresis Zacute zacute Zdotaccent zdotaccent Zcaron zcaron longs Ohorn ohorn Uhorn uhorn uni01C4 uni01C5 uni01C6 uni01CD uni01CE uni01CF uni01D1 uni01D2 uni01D3 uni01D4 uni01D5 uni01D6 uni01D7 uni01D8 uni01D9 uni01DA uni01DB uni01DC uni01DE uni01DF uni01E0 uni01E1 uni01E2 uni01E3 Gcaron uni01E8 uni01E9 uni01F1 uni01F2 uni01F3 uni01F4 uni01F8 uni01F9 Aringacute aringacute AEacute aeacute Oslashacute oslashacute uni0202 uni0203 uni0206 uni0207 uni020A uni020B uni020E uni020F uni0212 uni0213 uni0216 uni0217 uni021E uni021F uni0226 uni0227 uni022A uni022B uni022C uni022D uni022E uni022F uni0230 uni0231 uni0232 f.DEU u.LAT v.LATmedi f_f f_i f_l f_f_i f_f_l longs_t s_t f_f.long f.long f_h f_k f_b f_t longs_b longs_h longs_k longs.long longs_longs.long f_f_h f_f_k f_f_b f_f_t longs_longs_b longs_longs_h longs_longs_k longs_longs_t longs_s c_t germandbls.alt
   FCoverage: 2041 A B C D E F G H I K L M N O P R S T U V W X Y Z a b c d e f h k m n o r s t u v w x z Agrave Aacute Acircumflex Atilde Adieresis Aring AE Egrave Eacute Ecircumflex Edieresis Igrave Iacute Icircumflex Idieresis Eth Ntilde Ograve Oacute Ocircumflex Otilde Odieresis Oslash Ugrave Uacute Ucircumflex Udieresis Yacute Thorn germandbls agrave aacute acircumflex atilde adieresis aring ae egrave eacute ecircumflex edieresis eth ntilde ograve oacute ocircumflex otilde odieresis oslash ugrave uacute ucircumflex udieresis Amacron amacron Abreve abreve Cacute cacute Ccircumflex ccircumflex Cdotaccent cdotaccent Ccaron ccaron Dcaron dcaron Dcroat dcroat Emacron emacron Ebreve ebreve Edotaccent edotaccent Ecaron ecaron Gcircumflex Gbreve Gdotaccent Hcircumflex hcircumflex Hbar hbar Itilde Imacron Ibreve Idotaccent kgreenlandic Lacute Lcaron Ldot Lslash Nacute nacute Ncaron ncaron napostrophe Omacron omacron Obreve obreve Ohungarumlaut ohungarumlaut OE oe Racute racute Rcaron rcaron Sacute sacute Scircumflex scircumflex Scaron scaron Tcaron tcaron Tbar tbar Utilde utilde Umacron umacron Ubreve ubreve Uring uring Uhungarumlaut uhungarumlaut Wcircumflex wcircumflex Ycircumflex Ydieresis Zacute zacute Zdotaccent zdotaccent Zcaron zcaron longs Ohorn ohorn Uhorn uhorn uni01C4 uni01C5 uni01C6 uni01CD uni01CE uni01CF uni01D1 uni01D2 uni01D3 uni01D4 uni01D5 uni01D6 uni01D7 uni01D8 uni01D9 uni01DA uni01DB uni01DC uni01DE uni01DF uni01E0 uni01E1 uni01E2 uni01E3 Gcaron uni01E8 uni01E9 uni01F1 uni01F2 uni01F3 uni01F4 uni01F8 uni01F9 Aringacute aringacute AEacute aeacute Oslashacute oslashacute uni0202 uni0203 uni0206 uni0207 uni020A uni020B uni020E uni020F uni0212 uni0213 uni0216 uni0217 uni021E uni021F uni0226 uni0227 uni022A uni022B uni022C uni022D uni022E uni022F uni0230 uni0231 uni0232 f.DEU u.LAT v.LATmedi f_f f_i f_l f_f_i f_f_l longs_t s_t f_f.long f.long f_h f_k f_b f_t longs_b longs_h longs_k longs.long longs_longs.long f_f_h f_f_k f_f_b f_f_t longs_longs_b longs_longs_h longs_longs_k longs_longs_t longs_s c_t germandbls.alt
  1
-  SeqLookup: 0 "Single Substitution lookup 66" 
+  SeqLookup: 0 "Single Substitution lookup 66"
 EndFPST
-ChainSub2: coverage "Smallcaps2 contextual 1"  0 0 0 1
+ChainSub2: coverage "Smallcaps2 contextual 1" 0 0 0 1
  1 1 0
   Coverage: 10 uni0312.sc
   BCoverage: 4 g.sc
  1
-  SeqLookup: 0 "Single Substitution lookup 61" 
+  SeqLookup: 0 "Single Substitution lookup 61"
 EndFPST
-ChainSub2: coverage "Smallcaps2 contextual 0"  0 0 0 1
+ChainSub2: coverage "Smallcaps2 contextual 0" 0 0 0 1
  1 1 0
   Coverage: 24 uni030C.alt uni030C.alt1
   BCoverage: 19 D.sc d.sc T.sc t.sc
  1
-  SeqLookup: 0 "Single Substitution lookup 60" 
+  SeqLookup: 0 "Single Substitution lookup 60"
 EndFPST
-ChainSub2: coverage "historic_apostrophe subtable"  0 0 0 1
+ChainSub2: coverage "historic_apostrophe subtable" 0 0 0 1
  1 0 1
   Coverage: 10 quoteright
   FCoverage: 210 a c e g m n o p q r s u v w x y z ae ccedilla aogonek eogonek dotlessi kgreenlandic eng oe uni0157 scedilla uogonek uni01DD uni01E5 uni01EB uni0219 uni0229 uni0237 u.LAT u.LATmedi v.LAT v.LATmedi germandbls.alt
  1
-  SeqLookup: 0 "Single Substitution lookup 48" 
+  SeqLookup: 0 "Single Substitution lookup 48"
 EndFPST
-ChainSub2: coverage "longs_replacement subtable"  0 0 0 1
+ChainSub2: coverage "longs_replacement subtable" 0 0 0 1
  1 0 1
   Coverage: 1 s
   FCoverage: 319 a b c d e f g h i j k l m n o p q r s t u v w x y z longs germandbls adieresis edieresis odieresis udieresis idieresis aacute eacute iacute oacute uacute agrave egrave igrave ograve ugrave atilde uni1EBD otilde utilde oe f.DEU f.long i.TRK u.LAT u.LATmedi v.LAT v.LATmedi longs.long f.long germandbls.alt hyphen uni200D
  1
-  SeqLookup: 0 "Single Substitution lookup 44" 
+  SeqLookup: 0 "Single Substitution lookup 44"
 EndFPST
-ChainSub2: coverage "historic_u contextual 4"  0 0 0 1
+ChainSub2: coverage "historic_u contextual 4" 0 0 0 1
  1 0 0
   Coverage: 9 U.sc u.sc
  1
-  SeqLookup: 0 "Single Substitution lookup 42" 
+  SeqLookup: 0 "Single Substitution lookup 42"
 EndFPST
-ChainSub2: glyph "historic_u contextual 3"  0 0 0 1
+ChainSub2: glyph "historic_u contextual 3" 0 0 0 1
  String: 1 U
  BString: 0 
  FString: 0 
  1
-  SeqLookup: 0 "Single Substitution lookup 41" 
+  SeqLookup: 0 "Single Substitution lookup 41"
 EndFPST
-ChainSub2: coverage "historic_u contextual 2"  0 0 0 1
+ChainSub2: coverage "historic_u contextual 2" 0 0 0 1
  1 1 0
   Coverage: 1 v
   BCoverage: 1347 A B C D E F G H I J K L M N O P Q R S T U V W X Y Z Agrave Aacute Acircumflex Atilde Adieresis Aring AE Ccedilla Egrave Eacute Ecircumflex Edieresis Igrave Iacute Icircumflex Idieresis Eth Ntilde Ograve Oacute Ocircumflex Otilde Odieresis Oslash Ugrave Uacute Ucircumflex Udieresis Yacute Thorn Amacron Abreve Aogonek Cacute Ccircumflex Cdotaccent Ccaron Dcaron Dcroat Emacron Ebreve Edotaccent Eogonek Ecaron Gcircumflex Gbreve Gdotaccent uni0122 Hcircumflex Hbar Itilde Imacron Ibreve Iogonek Idotaccent IJ Jcircumflex uni0136 Lacute uni013B Lcaron Ldot Lslash Nacute uni0145 Ncaron Eng Omacron Obreve Ohungarumlaut OE Racute uni0156 Rcaron Sacute Scircumflex Scedilla Scaron uni0162 Tcaron Tbar Utilde Umacron Ubreve Uring Uhungarumlaut Uogonek Wcircumflex Ycircumflex Ydieresis Zacute Zdotaccent Zcaron Q.long U.LAT a b c d e f g h i j k l m n o p q r s t u v w x y z longs germandbls adieresis edieresis odieresis udieresis idieresis aacute eacute iacute oacute uacute agrave egrave igrave ograve ugrave atilde uni1EBD otilde utilde oe f.DEU f.long i.TRK u.LAT u.LATmedi v.LAT v.LATmedi longs.long f.long germandbls.alt f_f f_i f_l f_f_i f_f_l longs_t s_t longs_longs_l longs_longs_i longs_i longs_longs longs_l T_h c_h c_k longs_s c_t f_f.long t_t f_h f_k f_b f_t f_j longs_j longs_b longs_h longs_k longs_longs.long quoteright quoteright.01
  1
-  SeqLookup: 0 "Single Substitution lookup 40" 
+  SeqLookup: 0 "Single Substitution lookup 40"
 EndFPST
-ChainSub2: glyph "historic_u contextual 1"  0 0 0 1
+ChainSub2: glyph "historic_u contextual 1" 0 0 0 1
  String: 1 u
  BString: 0 
  FString: 0 
  1
-  SeqLookup: 0 "Single Substitution lookup 39" 
+  SeqLookup: 0 "Single Substitution lookup 39"
 EndFPST
-ChainSub2: coverage "historic_u contextual 0"  0 0 0 1
+ChainSub2: coverage "historic_u contextual 0" 0 0 0 1
  1 1 0
   Coverage: 1 u
   BCoverage: 1347 A B C D E F G H I J K L M N O P Q R S T U V W X Y Z Agrave Aacute Acircumflex Atilde Adieresis Aring AE Ccedilla Egrave Eacute Ecircumflex Edieresis Igrave Iacute Icircumflex Idieresis Eth Ntilde Ograve Oacute Ocircumflex Otilde Odieresis Oslash Ugrave Uacute Ucircumflex Udieresis Yacute Thorn Amacron Abreve Aogonek Cacute Ccircumflex Cdotaccent Ccaron Dcaron Dcroat Emacron Ebreve Edotaccent Eogonek Ecaron Gcircumflex Gbreve Gdotaccent uni0122 Hcircumflex Hbar Itilde Imacron Ibreve Iogonek Idotaccent IJ Jcircumflex uni0136 Lacute uni013B Lcaron Ldot Lslash Nacute uni0145 Ncaron Eng Omacron Obreve Ohungarumlaut OE Racute uni0156 Rcaron Sacute Scircumflex Scedilla Scaron uni0162 Tcaron Tbar Utilde Umacron Ubreve Uring Uhungarumlaut Uogonek Wcircumflex Ycircumflex Ydieresis Zacute Zdotaccent Zcaron Q.long U.LAT a b c d e f g h i j k l m n o p q r s t u v w x y z longs germandbls adieresis edieresis odieresis udieresis idieresis aacute eacute iacute oacute uacute agrave egrave igrave ograve ugrave atilde uni1EBD otilde utilde oe f.DEU f.long i.TRK u.LAT u.LATmedi v.LAT v.LATmedi longs.long f.long germandbls.alt f_f f_i f_l f_f_i f_f_l longs_t s_t longs_longs_l longs_longs_i longs_i longs_longs longs_l T_h c_h c_k longs_s c_t f_f.long t_t f_h f_k f_b f_t f_j longs_j longs_b longs_h longs_k longs_longs.long quoteright quoteright.01
  0
 EndFPST
-ChainSub2: coverage "frac contextual 1"  0 0 0 1
+ChainSub2: coverage "frac contextual 1" 0 0 0 1
  1 0 1
   Coverage: 49 zero one two three four five six seven eight nine
   FCoverage: 164 slash fraction zero one two three four five six seven eight nine zero.ordn one.ordn two.ordn three.ordn four.ordn five.ordn six.ordn seven.ordn eight.ordn nine.ordn
  1
-  SeqLookup: 0 "Single Substitution lookup 32" 
+  SeqLookup: 0 "Single Substitution lookup 32"
 EndFPST
-ChainSub2: coverage "frac contextual 0"  0 0 0 1
+ChainSub2: coverage "frac contextual 0" 0 0 0 1
  1 1 0
   Coverage: 49 zero one two three four five six seven eight nine
   BCoverage: 164 slash fraction zero one two three four five six seven eight nine zero.subs one.subs two.subs three.subs four.subs five.subs six.subs seven.subs eight.subs nine.subs
  1
-  SeqLookup: 0 "Single Substitution lookup 31" 
+  SeqLookup: 0 "Single Substitution lookup 31"
 EndFPST
-ChainSub2: coverage "CCMP_stackgrk2 subtable"  0 0 0 1
+ChainSub2: coverage "CCMP_stackgrk2 subtable" 0 0 0 1
  1 1 0
   Coverage: 19 gravecomb acutecomb
   BCoverage: 23 uni0313.grk uni0314.grk
  1
-  SeqLookup: 0 "Single Substitution lookup 24" 
+  SeqLookup: 0 "Single Substitution lookup 24"
 EndFPST
-ChainSub2: coverage "CCMP_stackgrk1 contextual 3"  0 0 0 1
+ChainSub2: coverage "CCMP_stackgrk1 contextual 3" 0 0 0 1
  1 1 0
   Coverage: 19 gravecomb acutecomb
   BCoverage: 91 alpha epsilon eta iota omicron upsilon omega Alpha Epsilon Eta Iota Omicron Upsilon uni03A9
  1
-  SeqLookup: 0 "Single Substitution lookup 22" 
+  SeqLookup: 0 "Single Substitution lookup 22"
 EndFPST
-ChainSub2: coverage "CCMP_stackgrk1 contextual 2"  0 0 0 1
+ChainSub2: coverage "CCMP_stackgrk1 contextual 2" 0 0 0 1
  1 1 1
   Coverage: 15 uni0313 uni0314
   BCoverage: 91 alpha epsilon eta iota omicron upsilon omega Alpha Epsilon Eta Iota Omicron Upsilon uni03A9
   FCoverage: 19 uni0342 uni0342.alt
  1
-  SeqLookup: 0 "Single Substitution lookup 21" 
+  SeqLookup: 0 "Single Substitution lookup 21"
 EndFPST
-ChainSub2: coverage "CCMP_stackgrk1 contextual 1"  0 0 0 1
+ChainSub2: coverage "CCMP_stackgrk1 contextual 1" 0 0 0 1
  1 1 1
   Coverage: 15 uni0313 uni0314
   BCoverage: 91 alpha epsilon eta iota omicron upsilon omega Alpha Epsilon Eta Iota Omicron Upsilon uni03A9
   FCoverage: 19 gravecomb acutecomb
  1
-  SeqLookup: 0 "Single Substitution lookup 20" 
+  SeqLookup: 0 "Single Substitution lookup 20"
 EndFPST
-ChainSub2: coverage "CCMP_stackgrk1 contextual 0"  0 0 0 1
+ChainSub2: coverage "CCMP_stackgrk1 contextual 0" 0 0 0 1
  1 1 1
   Coverage: 7 uni0308
   BCoverage: 91 alpha epsilon eta iota omicron upsilon omega Alpha Epsilon Eta Iota Omicron Upsilon uni03A9
   FCoverage: 19 gravecomb acutecomb
  1
-  SeqLookup: 0 "Single Substitution lookup 19" 
+  SeqLookup: 0 "Single Substitution lookup 19"
 EndFPST
-ChainSub2: coverage "CCMP_stacking2 subtable"  0 0 0 1
+ChainSub2: coverage "CCMP_stacking2 subtable" 0 0 0 1
  1 1 0
   Coverage: 91 acutecomb gravecomb uni0302 tildecomb uni0304 uni0306 uni0307 hookabovecomb uni030A uni030C
   BCoverage: 175 acutecomb.flat gravecomb.flat uni0302.stack tildecomb.stack uni0304.stack uni0306.stack uni0307.stack hookabovecomb.stack uni030A.stack uni030C.stack uni0302.flat uni030C.flat
  1
-  SeqLookup: 0 "Single Substitution lookup 17" 
+  SeqLookup: 0 "Single Substitution lookup 17"
 EndFPST
-ChainSub2: coverage "CCMP_stacking1 subtable"  0 0 0 1
+ChainSub2: coverage "CCMP_stacking1 subtable" 0 0 0 1
  1 0 1
   Coverage: 91 acutecomb gravecomb uni0302 tildecomb uni0304 uni0306 uni0307 hookabovecomb uni030A uni030C
   FCoverage: 255 gravecomb acutecomb uni0302 tildecomb uni0304 uni0305 uni0306 uni0307 uni0308 hookabovecomb uni030A uni030B uni030C uni030D uni030E uni030F uni0310 uni0311 uni0312 uni0313 uni0314 uni033D uni033E uni0340 uni0341 uni0351 uni0357 uni0364 uni1DD3 uni0306.cyr
  1
-  SeqLookup: 0 "Single Substitution lookup 15" 
+  SeqLookup: 0 "Single Substitution lookup 15"
 EndFPST
-ChainSub2: coverage "CCMP_contextual contextual 2"  0 0 0 1
+ChainSub2: coverage "CCMP_contextual contextual 2" 0 0 0 1
  1 1 0
   Coverage: 35 gravecomb acutecomb uni0302 uni030C
   BCoverage: 17 b d f h k l thorn
  1
-  SeqLookup: 0 "Single Substitution lookup 13" 
+  SeqLookup: 0 "Single Substitution lookup 13"
 EndFPST
-ChainSub2: coverage "CCMP_contextual contextual 1"  0 0 0 1
+ChainSub2: coverage "CCMP_contextual contextual 1" 0 0 0 1
  1 1 0
   Coverage: 7 uni030C
   BCoverage: 5 l d t
  1
-  SeqLookup: 0 "Single Substitution lookup 12" 
+  SeqLookup: 0 "Single Substitution lookup 12"
 EndFPST
-ChainSub2: coverage "CCMP_contextual contextual 0"  0 0 0 1
+ChainSub2: coverage "CCMP_contextual contextual 0" 0 0 0 1
  1 0 1
   Coverage: 3 i j
   FCoverage: 255 gravecomb acutecomb uni0302 tildecomb uni0304 uni0305 uni0306 uni0307 uni0308 hookabovecomb uni030A uni030B uni030C uni030D uni030E uni030F uni0310 uni0311 uni0312 uni0313 uni0314 uni033D uni033E uni0340 uni0341 uni0351 uni0357 uni0364 uni1DD3 uni0306.cyr
  1
-  SeqLookup: 0 "Single Substitution lookup 11" 
+  SeqLookup: 0 "Single Substitution lookup 11"
 EndFPST
-ChainSub2: coverage "loclCAT contextual 1"  0 0 0 1
+ChainSub2: coverage "loclCAT contextual 1" 0 0 0 1
  1 1 1
   Coverage: 14 periodcentered
   BCoverage: 1 L
   FCoverage: 3 L l
  1
-  SeqLookup: 0 "Single Substitution lookup 4" 
+  SeqLookup: 0 "Single Substitution lookup 4"
 EndFPST
-ChainSub2: glyph "loclCAT contextual 0"  0 0 0 1
+ChainSub2: glyph "loclCAT contextual 0" 0 0 0 1
  String: 14 periodcentered
  BString: 1 l
  FString: 1 l
  1
-  SeqLookup: 0 "Single Substitution lookup 3" 
+  SeqLookup: 0 "Single Substitution lookup 3"
 EndFPST
-ChainPos2: coverage "ckern2 contextual 1"  0 0 0 1
+ChainPos2: coverage "ckern2 contextual 1" 0 0 0 1
  1 0 2
   Coverage: 68 Upsilon Upsilontonos Upsilondieresis uni1F59 uni1F5B uni1F5D uni1F5F
   FCoverage: 401 uni0308 uni0313 uni0314 uni0342 uni0342.alt gravecomb.grk acutecomb.grk uni0313.grk uni0314.grk gravecomb.grkstack acutecomb.grkstack uni0308.grkstack uni0313.grkstack uni0314.grkstack uni0308.sc uni0313.sc uni0314.sc uni0342.sc gravecomb.grksc acutecomb.grksc uni0313.grksc uni0314.grksc gravecomb.grkstacksc acutecomb.grkstacksc uni0308.grkstacksc uni0313.grkstacksc uni0314.grkstacksc uni0342.altsc
   FCoverage: 114 alpha uni1FB3 gamma epsilon eta uni1FC3 iota kappa mu nu omicron pi rho sigma sigma1 tau upsilon chi omega uni1FF3
  1
-  SeqLookup: 0 "Single Positioning lookup 33" 
+  SeqLookup: 0 "Single Positioning lookup 33"
 EndFPST
-ChainPos2: coverage "ckern2 contextual 0"  0 0 0 1
+ChainPos2: coverage "ckern2 contextual 0" 0 0 0 1
  1 0 3
   Coverage: 68 Upsilon Upsilontonos Upsilondieresis uni1F59 uni1F5B uni1F5D uni1F5F
   FCoverage: 401 uni0308 uni0313 uni0314 uni0342 uni0342.alt gravecomb.grk acutecomb.grk uni0313.grk uni0314.grk gravecomb.grkstack acutecomb.grkstack uni0308.grkstack uni0313.grkstack uni0314.grkstack uni0308.sc uni0313.sc uni0314.sc uni0342.sc gravecomb.grksc acutecomb.grksc uni0313.grksc uni0314.grksc gravecomb.grkstacksc acutecomb.grkstacksc uni0308.grkstacksc uni0313.grkstacksc uni0314.grkstacksc uni0342.altsc
   FCoverage: 401 uni0308 uni0313 uni0314 uni0342 uni0342.alt gravecomb.grk acutecomb.grk uni0313.grk uni0314.grk gravecomb.grkstack acutecomb.grkstack uni0308.grkstack uni0313.grkstack uni0314.grkstack uni0308.sc uni0313.sc uni0314.sc uni0342.sc gravecomb.grksc acutecomb.grksc uni0313.grksc uni0314.grksc gravecomb.grkstacksc acutecomb.grkstacksc uni0308.grkstacksc uni0313.grkstacksc uni0314.grkstacksc uni0342.altsc
   FCoverage: 114 alpha uni1FB3 gamma epsilon eta uni1FC3 iota kappa mu nu omicron pi rho sigma sigma1 tau upsilon chi omega uni1FF3
  1
-  SeqLookup: 0 "Single Positioning lookup 32" 
+  SeqLookup: 0 "Single Positioning lookup 32"
 EndFPST
-ChainPos2: coverage "ckern1 contextual 28"  0 0 0 1
+ChainPos2: coverage "ckern1 contextual 28" 0 0 0 1
  1 0 1
   Coverage: 49 Alpha.sc Eta.sc Omega.sc alpha.sc eta.sc omega.sc
   FCoverage: 11 uni0345.sc1
  1
-  SeqLookup: 0 "Single Positioning lookup 30" 
+  SeqLookup: 0 "Single Positioning lookup 30"
 EndFPST
-ChainPos2: glyph "ckern1 contextual 27"  0 0 0 1
+ChainPos2: glyph "ckern1 contextual 27" 0 0 0 1
  String: 5 Omega
  BString: 0 
  FString: 11 uni0345.sc1
  1
-  SeqLookup: 0 "Single Positioning lookup 29" 
+  SeqLookup: 0 "Single Positioning lookup 29"
 EndFPST
-ChainPos2: glyph "ckern1 contextual 26"  0 0 0 1
+ChainPos2: glyph "ckern1 contextual 26" 0 0 0 1
  String: 5 Omega
  BString: 0 
  FString: 12 uni0345.cap2
  1
-  SeqLookup: 0 "Single Positioning lookup 28" 
+  SeqLookup: 0 "Single Positioning lookup 28"
 EndFPST
-ChainPos2: glyph "ckern1 contextual 25"  0 0 0 1
+ChainPos2: glyph "ckern1 contextual 25" 0 0 0 1
  String: 5 Omega
  BString: 0 
  FString: 12 uni0345.cap1
  1
-  SeqLookup: 0 "Single Positioning lookup 27" 
+  SeqLookup: 0 "Single Positioning lookup 27"
 EndFPST
-ChainPos2: coverage "ckern1 contextual 24"  0 0 0 1
+ChainPos2: coverage "ckern1 contextual 24" 0 0 0 1
  1 0 2
   Coverage: 5 Omega
   FCoverage: 11 uni0345.sc1
   FCoverage: 267 uni0313.grk uni0314.grk gravecomb.grkstack acutecomb.grkstack uni0308 uni0313.grkstack uni0314.grkstack uni0342 uni0342.alt uni0313.grksc uni0314.grksc gravecomb.grkstacksc acutecomb.grkstacksc uni0308.sc uni0313.grkstacksc uni0314.grkstacksc uni0342.sc uni0342.altsc
  1
-  SeqLookup: 0 "Single Positioning lookup 26" 
+  SeqLookup: 0 "Single Positioning lookup 26"
 EndFPST
-ChainPos2: coverage "ckern1 contextual 23"  0 0 0 1
+ChainPos2: coverage "ckern1 contextual 23" 0 0 0 1
  1 0 2
   Coverage: 5 Omega
   FCoverage: 12 uni0345.cap2
   FCoverage: 267 uni0313.grk uni0314.grk gravecomb.grkstack acutecomb.grkstack uni0308 uni0313.grkstack uni0314.grkstack uni0342 uni0342.alt uni0313.grksc uni0314.grksc gravecomb.grkstacksc acutecomb.grkstacksc uni0308.sc uni0313.grkstacksc uni0314.grkstacksc uni0342.sc uni0342.altsc
  1
-  SeqLookup: 0 "Single Positioning lookup 25" 
+  SeqLookup: 0 "Single Positioning lookup 25"
 EndFPST
-ChainPos2: coverage "ckern1 contextual 22"  0 0 0 1
+ChainPos2: coverage "ckern1 contextual 22" 0 0 0 1
  1 0 2
   Coverage: 5 Omega
   FCoverage: 12 uni0345.cap1
   FCoverage: 267 uni0313.grk uni0314.grk gravecomb.grkstack acutecomb.grkstack uni0308 uni0313.grkstack uni0314.grkstack uni0342 uni0342.alt uni0313.grksc uni0314.grksc gravecomb.grkstacksc acutecomb.grkstacksc uni0308.sc uni0313.grkstacksc uni0314.grkstacksc uni0342.sc uni0342.altsc
  1
-  SeqLookup: 0 "Single Positioning lookup 24" 
+  SeqLookup: 0 "Single Positioning lookup 24"
 EndFPST
-ChainPos2: coverage "ckern1 contextual 21"  0 0 0 1
+ChainPos2: coverage "ckern1 contextual 21" 0 0 0 1
  1 0 2
   Coverage: 5 Omega
   FCoverage: 11 uni0345.cap
   FCoverage: 267 uni0313.grk uni0314.grk gravecomb.grkstack acutecomb.grkstack uni0308 uni0313.grkstack uni0314.grkstack uni0342 uni0342.alt uni0313.grksc uni0314.grksc gravecomb.grkstacksc acutecomb.grkstacksc uni0308.sc uni0313.grkstacksc uni0314.grkstacksc uni0342.sc uni0342.altsc
  1
-  SeqLookup: 0 "Single Positioning lookup 23" 
+  SeqLookup: 0 "Single Positioning lookup 23"
 EndFPST
-ChainPos2: coverage "ckern1 contextual 20"  0 0 0 1
+ChainPos2: coverage "ckern1 contextual 20" 0 0 0 1
  1 0 1
   Coverage: 5 Omega
   FCoverage: 267 uni0313.grk uni0314.grk gravecomb.grkstack acutecomb.grkstack uni0308 uni0313.grkstack uni0314.grkstack uni0342 uni0342.alt uni0313.grksc uni0314.grksc gravecomb.grkstacksc acutecomb.grkstacksc uni0308.sc uni0313.grkstacksc uni0314.grkstacksc uni0342.sc uni0342.altsc
  1
-  SeqLookup: 0 "Single Positioning lookup 22" 
+  SeqLookup: 0 "Single Positioning lookup 22"
 EndFPST
-ChainPos2: coverage "ckern1 contextual 19"  0 0 0 1
+ChainPos2: coverage "ckern1 contextual 19" 0 0 0 1
  1 0 1
   Coverage: 7 Upsilon
   FCoverage: 267 uni0313.grk uni0314.grk gravecomb.grkstack acutecomb.grkstack uni0308 uni0313.grkstack uni0314.grkstack uni0342 uni0342.alt uni0313.grksc uni0314.grksc gravecomb.grkstacksc acutecomb.grkstacksc uni0308.sc uni0313.grkstacksc uni0314.grkstacksc uni0342.sc uni0342.altsc
  1
-  SeqLookup: 0 "Single Positioning lookup 21" 
+  SeqLookup: 0 "Single Positioning lookup 21"
 EndFPST
-ChainPos2: coverage "ckern1 contextual 18"  0 0 0 1
+ChainPos2: coverage "ckern1 contextual 18" 0 0 0 1
  1 0 1
   Coverage: 7 Upsilon
   FCoverage: 97 uni0313 uni0314 gravecomb.grk acutecomb.grk uni0313.sc uni0314.sc gravecomb.grksc acutecomb.grksc
  1
-  SeqLookup: 0 "Single Positioning lookup 20" 
+  SeqLookup: 0 "Single Positioning lookup 20"
 EndFPST
-ChainPos2: coverage "ckern1 contextual 17"  0 0 0 1
+ChainPos2: coverage "ckern1 contextual 17" 0 0 0 1
  1 0 1
   Coverage: 7 Omicron
   FCoverage: 267 uni0313.grk uni0314.grk gravecomb.grkstack acutecomb.grkstack uni0308 uni0313.grkstack uni0314.grkstack uni0342 uni0342.alt uni0313.grksc uni0314.grksc gravecomb.grkstacksc acutecomb.grkstacksc uni0308.sc uni0313.grkstacksc uni0314.grkstacksc uni0342.sc uni0342.altsc
  1
-  SeqLookup: 0 "Single Positioning lookup 19" 
+  SeqLookup: 0 "Single Positioning lookup 19"
 EndFPST
-ChainPos2: coverage "ckern1 contextual 16"  0 0 0 1
+ChainPos2: coverage "ckern1 contextual 16" 0 0 0 1
  1 0 1
   Coverage: 7 Omicron
   FCoverage: 97 uni0313 uni0314 gravecomb.grk acutecomb.grk uni0313.sc uni0314.sc gravecomb.grksc acutecomb.grksc
  1
-  SeqLookup: 0 "Single Positioning lookup 18" 
+  SeqLookup: 0 "Single Positioning lookup 18"
 EndFPST
-ChainPos2: glyph "ckern1 contextual 15"  0 0 0 1
+ChainPos2: glyph "ckern1 contextual 15" 0 0 0 1
  String: 3 Eta
  BString: 0 
  FString: 11 uni0345.sc1
  1
-  SeqLookup: 0 "Single Positioning lookup 17" 
+  SeqLookup: 0 "Single Positioning lookup 17"
 EndFPST
-ChainPos2: glyph "ckern1 contextual 14"  0 0 0 1
+ChainPos2: glyph "ckern1 contextual 14" 0 0 0 1
  String: 3 Eta
  BString: 0 
  FString: 12 uni0345.cap2
  1
-  SeqLookup: 0 "Single Positioning lookup 16" 
+  SeqLookup: 0 "Single Positioning lookup 16"
 EndFPST
-ChainPos2: glyph "ckern1 contextual 13"  0 0 0 1
+ChainPos2: glyph "ckern1 contextual 13" 0 0 0 1
  String: 3 Eta
  BString: 0 
  FString: 12 uni0345.cap1
  1
-  SeqLookup: 0 "Single Positioning lookup 15" 
+  SeqLookup: 0 "Single Positioning lookup 15"
 EndFPST
-ChainPos2: coverage "ckern1 contextual 12"  0 0 0 1
+ChainPos2: coverage "ckern1 contextual 12" 0 0 0 1
  1 0 2
   Coverage: 3 Eta
   FCoverage: 11 uni0345.sc1
   FCoverage: 267 uni0313.grk uni0314.grk gravecomb.grkstack acutecomb.grkstack uni0308 uni0313.grkstack uni0314.grkstack uni0342 uni0342.alt uni0313.grksc uni0314.grksc gravecomb.grkstacksc acutecomb.grkstacksc uni0308.sc uni0313.grkstacksc uni0314.grkstacksc uni0342.sc uni0342.altsc
  1
-  SeqLookup: 0 "Single Positioning lookup 14" 
+  SeqLookup: 0 "Single Positioning lookup 14"
 EndFPST
-ChainPos2: coverage "ckern1 contextual 11"  0 0 0 1
+ChainPos2: coverage "ckern1 contextual 11" 0 0 0 1
  1 0 2
   Coverage: 3 Eta
   FCoverage: 11 uni0345.sc1
   FCoverage: 97 uni0313 uni0314 gravecomb.grk acutecomb.grk uni0313.sc uni0314.sc gravecomb.grksc acutecomb.grksc
  1
-  SeqLookup: 0 "Single Positioning lookup 13" 
+  SeqLookup: 0 "Single Positioning lookup 13"
 EndFPST
-ChainPos2: coverage "ckern1 contextual 10"  0 0 0 1
+ChainPos2: coverage "ckern1 contextual 10" 0 0 0 1
  1 0 2
   Coverage: 3 Eta
   FCoverage: 12 uni0345.cap2
   FCoverage: 267 uni0313.grk uni0314.grk gravecomb.grkstack acutecomb.grkstack uni0308 uni0313.grkstack uni0314.grkstack uni0342 uni0342.alt uni0313.grksc uni0314.grksc gravecomb.grkstacksc acutecomb.grkstacksc uni0308.sc uni0313.grkstacksc uni0314.grkstacksc uni0342.sc uni0342.altsc
  1
-  SeqLookup: 0 "Single Positioning lookup 12" 
+  SeqLookup: 0 "Single Positioning lookup 12"
 EndFPST
-ChainPos2: coverage "ckern1 contextual 9"  0 0 0 1
+ChainPos2: coverage "ckern1 contextual 9" 0 0 0 1
  1 0 2
   Coverage: 3 Eta
   FCoverage: 12 uni0345.cap2
   FCoverage: 97 uni0313 uni0314 gravecomb.grk acutecomb.grk uni0313.sc uni0314.sc gravecomb.grksc acutecomb.grksc
  1
-  SeqLookup: 0 "Single Positioning lookup 11" 
+  SeqLookup: 0 "Single Positioning lookup 11"
 EndFPST
-ChainPos2: coverage "ckern1 contextual 8"  0 0 0 1
+ChainPos2: coverage "ckern1 contextual 8" 0 0 0 1
  1 0 2
   Coverage: 3 Eta
   FCoverage: 12 uni0345.cap1
   FCoverage: 267 uni0313.grk uni0314.grk gravecomb.grkstack acutecomb.grkstack uni0308 uni0313.grkstack uni0314.grkstack uni0342 uni0342.alt uni0313.grksc uni0314.grksc gravecomb.grkstacksc acutecomb.grkstacksc uni0308.sc uni0313.grkstacksc uni0314.grkstacksc uni0342.sc uni0342.altsc
  1
-  SeqLookup: 0 "Single Positioning lookup 10" 
+  SeqLookup: 0 "Single Positioning lookup 10"
 EndFPST
-ChainPos2: coverage "ckern1 contextual 7"  0 0 0 1
+ChainPos2: coverage "ckern1 contextual 7" 0 0 0 1
  1 0 2
   Coverage: 3 Eta
   FCoverage: 12 uni0345.cap1
   FCoverage: 97 uni0313 uni0314 gravecomb.grk acutecomb.grk uni0313.sc uni0314.sc gravecomb.grksc acutecomb.grksc
  1
-  SeqLookup: 0 "Single Positioning lookup 9" 
+  SeqLookup: 0 "Single Positioning lookup 9"
 EndFPST
-ChainPos2: coverage "ckern1 contextual 6"  0 0 0 1
+ChainPos2: coverage "ckern1 contextual 6" 0 0 0 1
  1 0 2
   Coverage: 3 Eta
   FCoverage: 11 uni0345.cap
   FCoverage: 267 uni0313.grk uni0314.grk gravecomb.grkstack acutecomb.grkstack uni0308 uni0313.grkstack uni0314.grkstack uni0342 uni0342.alt uni0313.grksc uni0314.grksc gravecomb.grkstacksc acutecomb.grkstacksc uni0308.sc uni0313.grkstacksc uni0314.grkstacksc uni0342.sc uni0342.altsc
  1
-  SeqLookup: 0 "Single Positioning lookup 8" 
+  SeqLookup: 0 "Single Positioning lookup 8"
 EndFPST
-ChainPos2: coverage "ckern1 contextual 5"  0 0 0 1
+ChainPos2: coverage "ckern1 contextual 5" 0 0 0 1
  1 0 2
   Coverage: 3 Eta
   FCoverage: 11 uni0345.cap
   FCoverage: 97 uni0313 uni0314 gravecomb.grk acutecomb.grk uni0313.sc uni0314.sc gravecomb.grksc acutecomb.grksc
  1
-  SeqLookup: 0 "Single Positioning lookup 7" 
+  SeqLookup: 0 "Single Positioning lookup 7"
 EndFPST
-ChainPos2: coverage "ckern1 contextual 4"  0 0 0 1
+ChainPos2: coverage "ckern1 contextual 4" 0 0 0 1
  1 0 1
   Coverage: 16 Epsilon Eta Iota
   FCoverage: 267 uni0313.grk uni0314.grk gravecomb.grkstack acutecomb.grkstack uni0308 uni0313.grkstack uni0314.grkstack uni0342 uni0342.alt uni0313.grksc uni0314.grksc gravecomb.grkstacksc acutecomb.grkstacksc uni0308.sc uni0313.grkstacksc uni0314.grkstacksc uni0342.sc uni0342.altsc
  1
-  SeqLookup: 0 "Single Positioning lookup 6" 
+  SeqLookup: 0 "Single Positioning lookup 6"
 EndFPST
-ChainPos2: coverage "ckern1 contextual 3"  0 0 0 1
+ChainPos2: coverage "ckern1 contextual 3" 0 0 0 1
  1 0 1
   Coverage: 20 Epsilon Eta Iota Rho
   FCoverage: 97 uni0313 uni0314 gravecomb.grk acutecomb.grk uni0313.sc uni0314.sc gravecomb.grksc acutecomb.grksc
  1
-  SeqLookup: 0 "Single Positioning lookup 5" 
+  SeqLookup: 0 "Single Positioning lookup 5"
 EndFPST
-ChainPos2: glyph "ckern1 contextual 2"  0 0 0 1
+ChainPos2: glyph "ckern1 contextual 2" 0 0 0 1
  String: 5 Alpha
  BString: 0 
  FString: 11 uni0345.sc1
  1
-  SeqLookup: 0 "Single Positioning lookup 4" 
+  SeqLookup: 0 "Single Positioning lookup 4"
 EndFPST
-ChainPos2: glyph "ckern1 contextual 1"  0 0 0 1
+ChainPos2: glyph "ckern1 contextual 1" 0 0 0 1
  String: 5 Alpha
  BString: 0 
  FString: 12 uni0345.cap2
  1
-  SeqLookup: 0 "Single Positioning lookup 3" 
+  SeqLookup: 0 "Single Positioning lookup 3"
 EndFPST
-ChainPos2: glyph "ckern1 contextual 0"  0 0 0 1
+ChainPos2: glyph "ckern1 contextual 0" 0 0 0 1
  String: 5 Alpha
  BString: 0 
  FString: 12 uni0345.cap1
  1
-  SeqLookup: 0 "Single Positioning lookup 2" 
+  SeqLookup: 0 "Single Positioning lookup 2"
 EndFPST
 ShortTable: maxp 16
   1
@@ -680,33 +681,33 @@ ShortTable: maxp 16
   0
   0
 EndShort
-LangName: 1055 "" "" "Normal" 
-LangName: 1053 "" "" "Normal" 
-LangName: 1034 "" "" "Normal" 
-LangName: 3082 "" "" "Normal" 
-LangName: 2058 "" "" "Normal" 
-LangName: 1060 "" "" "Navadno" 
-LangName: 1051 "" "" "Norm+AOEA-lne" 
-LangName: 1049 "" "" "+BB4EMQRLBEcEPQRLBDkA" 
-LangName: 1046 "" "" "Normal" 
-LangName: 2070 "" "" "Normal" 
-LangName: 1045 "" "" "Normalny" 
-LangName: 1044 "" "" "Normal" 
-LangName: 1040 "" "" "Normale" 
-LangName: 1038 "" "" "Norm+AOEA-l" 
-LangName: 1032 "" "" "+A5oDsQO9A78DvQO5A7oDrAAA" 
-LangName: 1036 "" "" "Normal" 
-LangName: 3084 "" "" "Normal" 
-LangName: 1035 "" "" "Normaali" 
-LangName: 1043 "" "" "Standaard" 
-LangName: 1030 "" "" "normal" 
-LangName: 1029 "" "" "oby+AQ0A-ejn+AOkA" 
-LangName: 1027 "" "" "Normal" 
-LangName: 1069 "" "" "Arrunta" 
-LangName: 1033 "" "" "" "" "" "" "" "" "" "" "" "" "" "Copyright 2012, Georg A. Duffner, (<www.georgduffner.at/ebgaramond | g.duffner@gmail.com).+AAoACgAA-This Font Software is licensed under the SIL Open Font License, Version 1.1.+AAoA-This license is copied below, and is also available with a FAQ at:+AAoA-http://scripts.sil.org/OFL+AAoACgAK------------------------------------------------------------+AAoA-SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007+AAoA------------------------------------------------------------+AAoACgAA-PREAMBLE+AAoA-The goals of the Open Font License (OFL) are to stimulate worldwide+AAoA-development of collaborative font projects, to support the font creation+AAoA-efforts of academic and linguistic communities, and to provide a free and+AAoA-open framework in which fonts may be shared and improved in partnership+AAoA-with others.+AAoACgAA-The OFL allows the licensed fonts to be used, studied, modified and+AAoA-redistributed freely as long as they are not sold by themselves. The+AAoA-fonts, including any derivative works, can be bundled, embedded, +AAoA-redistributed and/or sold with any software provided that any reserved+AAoA-names are not used by derivative works. The fonts and derivatives,+AAoA-however, cannot be released under any other type of license. The+AAoA-requirement for fonts to remain under this license does not apply+AAoA-to any document created using the fonts or their derivatives.+AAoACgAA-DEFINITIONS+AAoAIgAA-Font Software+ACIA refers to the set of files released by the Copyright+AAoA-Holder(s) under this license and clearly marked as such. This may+AAoA-include source files, build scripts and documentation.+AAoACgAi-Reserved Font Name+ACIA refers to any names specified as such after the+AAoA-copyright statement(s).+AAoACgAi-Original Version+ACIA refers to the collection of Font Software components as+AAoA-distributed by the Copyright Holder(s).+AAoACgAi-Modified Version+ACIA refers to any derivative made by adding to, deleting,+AAoA-or substituting -- in part or in whole -- any of the components of the+AAoA-Original Version, by changing formats or by porting the Font Software to a+AAoA-new environment.+AAoACgAi-Author+ACIA refers to any designer, engineer, programmer, technical+AAoA-writer or other person who contributed to the Font Software.+AAoACgAA-PERMISSION & CONDITIONS+AAoA-Permission is hereby granted, free of charge, to any person obtaining+AAoA-a copy of the Font Software, to use, study, copy, merge, embed, modify,+AAoA-redistribute, and sell modified and unmodified copies of the Font+AAoA-Software, subject to the following conditions:+AAoACgAA-1) Neither the Font Software nor any of its individual components,+AAoA-in Original or Modified Versions, may be sold by itself.+AAoACgAA-2) Original or Modified Versions of the Font Software may be bundled,+AAoA-redistributed and/or sold with any software, provided that each copy+AAoA-contains the above copyright notice and this license. These can be+AAoA-included either as stand-alone text files, human-readable headers or+AAoA-in the appropriate machine-readable metadata fields within text or+AAoA-binary files as long as those fields can be easily viewed by the user.+AAoACgAA-3) No Modified Version of the Font Software may use the Reserved Font+AAoA-Name(s) unless explicit written permission is granted by the corresponding+AAoA-Copyright Holder. This restriction only applies to the primary font name as+AAoA-presented to the users.+AAoACgAA-4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font+AAoA-Software shall not be used to promote, endorse or advertise any+AAoA-Modified Version, except to acknowledge the contribution(s) of the+AAoA-Copyright Holder(s) and the Author(s) or with their explicit written+AAoA-permission.+AAoACgAA-5) The Font Software, modified or unmodified, in part or in whole,+AAoA-must be distributed entirely under this license, and must not be+AAoA-distributed under any other license. The requirement for fonts to+AAoA-remain under this license does not apply to any document created+AAoA-using the Font Software.+AAoACgAA-TERMINATION+AAoA-This license becomes null and void if any of the above conditions are+AAoA-not met.+AAoACgAA-DISCLAIMER+AAoA-THE FONT SOFTWARE IS PROVIDED +ACIA-AS IS+ACIA, WITHOUT WARRANTY OF ANY KIND,+AAoA-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF+AAoA-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT+AAoA-OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE+AAoA-COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,+AAoA-INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL+AAoA-DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING+AAoA-FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM+AAoA-OTHER DEALINGS IN THE FONT SOFTWARE." "http://scripts.sil.org/OFL" "" "EB Garamond" "08 Regular" "EB Garamond 08 Regular" 
-LangName: 1031 "" "" "Standard" 
+LangName: 1055 "" "" "Normal"
+LangName: 1053 "" "" "Normal"
+LangName: 1034 "" "" "Normal"
+LangName: 3082 "" "" "Normal"
+LangName: 2058 "" "" "Normal"
+LangName: 1060 "" "" "Navadno"
+LangName: 1051 "" "" "Norm+AOEA-lne"
+LangName: 1049 "" "" "+BB4EMQRLBEcEPQRLBDkA"
+LangName: 1046 "" "" "Normal"
+LangName: 2070 "" "" "Normal"
+LangName: 1045 "" "" "Normalny"
+LangName: 1044 "" "" "Normal"
+LangName: 1040 "" "" "Normale"
+LangName: 1038 "" "" "Norm+AOEA-l"
+LangName: 1032 "" "" "+A5oDsQO9A78DvQO5A7oDrAAA"
+LangName: 1036 "" "" "Normal"
+LangName: 3084 "" "" "Normal"
+LangName: 1035 "" "" "Normaali"
+LangName: 1043 "" "" "Standaard"
+LangName: 1030 "" "" "normal"
+LangName: 1029 "" "" "oby+AQ0A-ejn+AOkA"
+LangName: 1027 "" "" "Normal"
+LangName: 1069 "" "" "Arrunta"
+LangName: 1033 "" "" "" "" "" "" "" "" "" "" "" "" "" "Copyright 2012, Georg A. Duffner, (<www.georgduffner.at/ebgaramond | g.duffner@gmail.com).+AAoACgAA-This Font Software is licensed under the SIL Open Font License, Version 1.1.+AAoA-This license is copied below, and is also available with a FAQ at:+AAoA-http://scripts.sil.org/OFL+AAoACgAK------------------------------------------------------------+AAoA-SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007+AAoA------------------------------------------------------------+AAoACgAA-PREAMBLE+AAoA-The goals of the Open Font License (OFL) are to stimulate worldwide+AAoA-development of collaborative font projects, to support the font creation+AAoA-efforts of academic and linguistic communities, and to provide a free and+AAoA-open framework in which fonts may be shared and improved in partnership+AAoA-with others.+AAoACgAA-The OFL allows the licensed fonts to be used, studied, modified and+AAoA-redistributed freely as long as they are not sold by themselves. The+AAoA-fonts, including any derivative works, can be bundled, embedded, +AAoA-redistributed and/or sold with any software provided that any reserved+AAoA-names are not used by derivative works. The fonts and derivatives,+AAoA-however, cannot be released under any other type of license. The+AAoA-requirement for fonts to remain under this license does not apply+AAoA-to any document created using the fonts or their derivatives.+AAoACgAA-DEFINITIONS+AAoAIgAA-Font Software+ACIA refers to the set of files released by the Copyright+AAoA-Holder(s) under this license and clearly marked as such. This may+AAoA-include source files, build scripts and documentation.+AAoACgAi-Reserved Font Name+ACIA refers to any names specified as such after the+AAoA-copyright statement(s).+AAoACgAi-Original Version+ACIA refers to the collection of Font Software components as+AAoA-distributed by the Copyright Holder(s).+AAoACgAi-Modified Version+ACIA refers to any derivative made by adding to, deleting,+AAoA-or substituting -- in part or in whole -- any of the components of the+AAoA-Original Version, by changing formats or by porting the Font Software to a+AAoA-new environment.+AAoACgAi-Author+ACIA refers to any designer, engineer, programmer, technical+AAoA-writer or other person who contributed to the Font Software.+AAoACgAA-PERMISSION & CONDITIONS+AAoA-Permission is hereby granted, free of charge, to any person obtaining+AAoA-a copy of the Font Software, to use, study, copy, merge, embed, modify,+AAoA-redistribute, and sell modified and unmodified copies of the Font+AAoA-Software, subject to the following conditions:+AAoACgAA-1) Neither the Font Software nor any of its individual components,+AAoA-in Original or Modified Versions, may be sold by itself.+AAoACgAA-2) Original or Modified Versions of the Font Software may be bundled,+AAoA-redistributed and/or sold with any software, provided that each copy+AAoA-contains the above copyright notice and this license. These can be+AAoA-included either as stand-alone text files, human-readable headers or+AAoA-in the appropriate machine-readable metadata fields within text or+AAoA-binary files as long as those fields can be easily viewed by the user.+AAoACgAA-3) No Modified Version of the Font Software may use the Reserved Font+AAoA-Name(s) unless explicit written permission is granted by the corresponding+AAoA-Copyright Holder. This restriction only applies to the primary font name as+AAoA-presented to the users.+AAoACgAA-4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font+AAoA-Software shall not be used to promote, endorse or advertise any+AAoA-Modified Version, except to acknowledge the contribution(s) of the+AAoA-Copyright Holder(s) and the Author(s) or with their explicit written+AAoA-permission.+AAoACgAA-5) The Font Software, modified or unmodified, in part or in whole,+AAoA-must be distributed entirely under this license, and must not be+AAoA-distributed under any other license. The requirement for fonts to+AAoA-remain under this license does not apply to any document created+AAoA-using the Font Software.+AAoACgAA-TERMINATION+AAoA-This license becomes null and void if any of the above conditions are+AAoA-not met.+AAoACgAA-DISCLAIMER+AAoA-THE FONT SOFTWARE IS PROVIDED +ACIA-AS IS+ACIA, WITHOUT WARRANTY OF ANY KIND,+AAoA-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF+AAoA-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT+AAoA-OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE+AAoA-COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,+AAoA-INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL+AAoA-DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING+AAoA-FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM+AAoA-OTHER DEALINGS IN THE FONT SOFTWARE." "http://scripts.sil.org/OFL" "" "EB Garamond" "08 Regular" "EB Garamond 08 Regular"
+LangName: 1031 "" "" "Standard"
 GaspTable: 1 65535 2 0
-DesignSize: 80 0-94 1 1033 "Regular" 
+DesignSize: 80 0-94 1 1033 "Regular"
 Encoding: UnicodeFull
 Compacted: 1
 UnicodeInterp: none
@@ -714,7 +715,7 @@ NameList: AGL For New Fonts
 DisplaySize: -96
 AntiAlias: 1
 FitToEm: 1
-WinInfo: 644 7 6
+WinInfo: 0 19 8
 BeginPrivate: 10
 OtherBlues 11 [-298 -252]
 BlueValues 39 [-12 0 417 430 547 564 585 608 671 712]
@@ -749,5 +750,5 @@ Grid
  195 448 216 453 250 453 c 4
 EndSplineSet
 TeXData: 1 8388608 0 217055 108527 72351 430965 1048576 72351 783286 444596 497025 792723 393216 433062 380633 303038 157286 324010 404750 52429 2506097 1059062 262144
-AnchorClass2: "top_accent"  "mark anchor 0" "cedilla"  "mark anchor 1" "ogonek"  "mark anchor 1" "top_right"  "mark anchor 2" "top_left"  "mark anchor 2" "below_accent"  "mark anchor 3" "top_stack"  "mkmk subtable" "acutestack"  "mkmk subtable" "gravestack"  "mkmk subtable" "hookstack"  "mkmk subtable" 
+AnchorClass2: "top_accent" "mark anchor 0" "cedilla" "mark anchor 1" "ogonek" "mark anchor 1" "top_right" "mark anchor 2" "top_left" "mark anchor 2" "below_accent" "mark anchor 3" "top_stack" "mkmk subtable" "acutestack" "mkmk subtable" "gravestack" "mkmk subtable" "hookstack" "mkmk subtable"
 EndSplineFont

--- a/SFD/EBGaramond08-Regular.sfdir/ldot.glyph
+++ b/SFD/EBGaramond08-Regular.sfdir/ldot.glyph
@@ -9,5 +9,5 @@ Refer: 745 183 N 1 0 0 1 169 0 2
 Refer: 76 108 N 1 0 0 1 0 0 2
 Validated: 32769
 Substitution2: "Smallcaps1 subtable" ldot.sc
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar

--- a/SFD/EBGaramond08-Regular.sfdir/longs_i.glyph
+++ b/SFD/EBGaramond08-Regular.sfdir/longs_i.glyph
@@ -48,5 +48,5 @@ SplineSet
 EndSplineSet
 Validated: 1
 Ligature2: "liga_standard subtable" longs i
-LCarets2: 1 265 
+LCarets2: 1 265
 EndChar

--- a/SFD/EBGaramond08-Regular.sfdir/longs_l.glyph
+++ b/SFD/EBGaramond08-Regular.sfdir/longs_l.glyph
@@ -45,5 +45,5 @@ SplineSet
 EndSplineSet
 Validated: 1
 Ligature2: "liga_standard subtable" longs l
-LCarets2: 1 281 
+LCarets2: 1 281
 EndChar

--- a/SFD/EBGaramond08-Regular.sfdir/longs_longs.glyph
+++ b/SFD/EBGaramond08-Regular.sfdir/longs_longs.glyph
@@ -53,5 +53,5 @@ EndSplineSet
 Validated: 1
 Substitution2: "Single Substitution lookup 72 subtable" longs_longs.short
 Ligature2: "liga_standard subtable" longs longs
-LCarets2: 1 267 
+LCarets2: 1 267
 EndChar

--- a/SFD/EBGaramond08-Regular.sfdir/longs_longs_i.glyph
+++ b/SFD/EBGaramond08-Regular.sfdir/longs_longs_i.glyph
@@ -68,5 +68,5 @@ SplineSet
 EndSplineSet
 Validated: 1
 Ligature2: "liga_standard subtable" longs longs i
-LCarets2: 2 270 521 
+LCarets2: 2 270 521
 EndChar

--- a/SFD/EBGaramond08-Regular.sfdir/longs_longs_l.glyph
+++ b/SFD/EBGaramond08-Regular.sfdir/longs_longs_l.glyph
@@ -64,5 +64,5 @@ SplineSet
 EndSplineSet
 Validated: 1
 Ligature2: "liga_standard subtable" longs longs l
-LCarets2: 2 256 530 
+LCarets2: 2 256 530
 EndChar

--- a/SFD/EBGaramond08-Regular.sfdir/longs_s.glyph
+++ b/SFD/EBGaramond08-Regular.sfdir/longs_s.glyph
@@ -53,5 +53,5 @@ SplineSet
 EndSplineSet
 Validated: 1
 Ligature2: "liga_standard subtable" longs s
-LCarets2: 1 276 
+LCarets2: 1 276
 EndChar

--- a/SFD/EBGaramond08-Regular.sfdir/longs_t.glyph
+++ b/SFD/EBGaramond08-Regular.sfdir/longs_t.glyph
@@ -8,5 +8,5 @@ Fore
 Refer: 200 64261 N 1 0 0 1 0 0 2
 Validated: 32769
 Ligature2: "liga_standard subtable" longs t
-LCarets2: 1 283 
+LCarets2: 1 283
 EndChar

--- a/SFD/EBGaramond08-Regular.sfdir/s_t.glyph
+++ b/SFD/EBGaramond08-Regular.sfdir/s_t.glyph
@@ -8,5 +8,5 @@ Fore
 Refer: 201 64262 N 1 0 0 1 0 0 2
 Validated: 32769
 Ligature2: "'hlig' Historic Ligatures lookup 62 subtable" s t
-LCarets2: 1 298 
+LCarets2: 1 298
 EndChar

--- a/SFD/EBGaramond08-Regular.sfdir/uni00AD.glyph
+++ b/SFD/EBGaramond08-Regular.sfdir/uni00AD.glyph
@@ -1,7 +1,17 @@
 StartChar: uni00AD
 Encoding: 173 173 2136
-Width: 0
-VWidth: 0
-Flags: MW
+Width: 386
+VWidth: 982
+Flags: HMW
 LayerCount: 2
+Fore
+SplineSet
+320 271 m 6
+ 334 272 351 266 351 243 c 12
+ 351 220 341 195 318 194 c 6
+ 99 176 l 6
+ 65 173 45 175 45 195 c 4
+ 45 214 56 249 82 252 c 6
+ 320 271 l 6
+EndSplineSet
 EndChar

--- a/SFD/EBGaramond08-Regular.sfdir/uniFB00.glyph
+++ b/SFD/EBGaramond08-Regular.sfdir/uniFB00.glyph
@@ -62,5 +62,5 @@ SplineSet
  180 426 l 2
 EndSplineSet
 Validated: 33
-LCarets2: 1 275 
+LCarets2: 1 275
 EndChar


### PR DESCRIPTION
On ereaders that use soft hyphens for wrapping text (like KOReader), EB Garamond 08 lacks a hyphen when wrapping lines because it's missing a `SOFT HYPHEN` character (`U+00AD`). I've added `SOFT HYPHEN` to Italic 08 and Regular 08 by copying the `HYPHEN-MINUS` data into the `SOFT HYPHEN` slot for both fonts. In Italic it was a new slot, unless I missed a similar empty one.

FontForge has auto-formatted a lot of the files here too (looks like trailing space removal, mostly). I've never used FontForge before, so I don't know which changes are important. Let me know if there's anything I should fix up.

Really excited for the potential to use size 8 on my ereader!