### PR TITLE
Make CI builds more easily accessible

### DIFF
--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -35,6 +35,9 @@ jobs:
       with:
         name: EBGaramond
         path: EBGaramond.zip
+        
+    - name: Tree
+      run: tree
 
     - name: Update nightly release
       if: success()

--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -43,5 +43,5 @@ jobs:
         tag: nightly
         rm: true
         token: ${{ secrets.GITHUB_TOKEN }}
-        files: EBGaramond
+        files: EBGaramond.zip
 

--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -31,10 +31,10 @@ jobs:
         name: EBGaramond
         path: build/EBGaramond*
 
-  - uses: actions/download-artifact@v3
-    with:
-      name: EBGaramond
-      path: EBGaramond.zip
+    - uses: actions/download-artifact@v3
+      with:
+        name: EBGaramond
+        path: EBGaramond.zip
 
     - name: Update nightly release
       if: success()

--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -31,6 +31,11 @@ jobs:
         name: EBGaramond
         path: build/EBGaramond*
 
+  - uses: actions/download-artifact@v3
+    with:
+      name: EBGaramond
+      path: EBGaramond.zip
+
     - name: Update nightly release
       if: success()
       uses: pyTooling/Actions/releaser@main
@@ -38,5 +43,5 @@ jobs:
         tag: nightly
         rm: true
         token: ${{ secrets.GITHUB_TOKEN }}
-        files: build/EBGaramond*
+        files: EBGaramond.zip
 

--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -43,5 +43,5 @@ jobs:
         tag: nightly
         rm: true
         token: ${{ secrets.GITHUB_TOKEN }}
-        files: EBGaramond.zip
+        files: EBGaramond
 

--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -4,7 +4,7 @@ on:
   - pull_request
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   linux-build:
@@ -30,4 +30,13 @@ jobs:
       with:
         name: EBGaramond
         path: build/EBGaramond*
+
+    - name: Update nightly release
+      if: success()
+      uses: pyTooling/Actions/releaser@main
+      with:
+        tag: nightly
+        rm: true
+        token: ${{ secrets.GITHUB_TOKEN }}
+        files: build/EBGaramond*
 

--- a/README.md
+++ b/README.md
@@ -9,28 +9,29 @@ For the use with Xe- and LuaLaTeX I’m working on a configuration for mycrotype
 
 ## Fonts in this repository:
 
-- EBGaramond12-Regular: Regular font for design size 12pt
-- EBGaramond12-Italic: Italic font for design size 12pt
-- EBGaramond12-Bold: Bold font for design size 12pt (very rough/unusable; not included in releases)
-- EBGaramond08-Regular: Regular font for design size 8pt
-- EBGaramond08-Italic: Italic font for design size 8pt (very rough spacing!)
-- EBGaramond12-SC: Smallcaps font for programs that ignore opentype features (12pt)
-- EBGaramond12-AllSC: All smallcaps font for programs that ignore opentype features
-- EBGaramond08-SC: Smallcaps font for programs that ignore opentype features (8pt)
-- EBGaramond-Initials: Initials
-- EBGaramond-InitialsF1: Background (the ornament) of initials
-- EBGaramond-InitialsF2: Foreground (the letter) of initials
-- EBGaramond-Lettrines: Workbench for Initials fonts (not included in releases)
+| Font | Description |
+|------|-------------|
+| EBGaramond-Initials | Initials
+| EBGaramond-InitialsF1 | Background (the ornament) of initials
+| EBGaramond-InitialsF2 | Foreground (the letter) of initials
+| EBGaramond-Lettrines | Workbench for Initials fonts (not included in releases)
+| EBGaramond08-Italic | Italic font for design size 8pt (very rough spacing!)
+| EBGaramond08-Regular | Regular font for design size 8pt
+| EBGaramond12-AllSC | All smallcaps font for programs that ignore opentype features
+| EBGaramond12-Italic | Italic font for design size 12pt
+| EBGaramond12-Regular | Regular font for design size 12pt
+| EBGaramond12-Bold | Bold font for design size 12pt (very rough/unusable; not included in releases)
+| EBGaramondSC08-Regular | Smallcaps font for programs that ignore opentype features (12pt)
+| EBGaramondSC08-Regular | Smallcaps font for programs that ignore opentype features (12pt)
+
 
 This is a work in progress, so expect bugs! The quality of the fonts still varies widely! You can see every font’s current state in its *-Glyphs.pdf file in the specimen section.
 
-## Mirrors:
+## Downloads:
 
-Due to Github deciding not to provide a download area any more, this project resides in two mirrored repositories on Github (https://github.com/georgd/EB-Garamond) and Bitbucket (https://bitbucket.org/georgd/eb-garamond). 
-
-- Downloadable zip-files are at https://bitbucket.org/georgd/eb-garamond/downloads
-- The issue tracker continues to live at https://github.com/georgd/EB-Garamond/issues
-- Forks and pull requests should be possible on both platforms
-
+| Type | URL |
+|------|-----|
+| Nightly build | https://github.com/georgd/EB-Garamond/releases/download/nightly/EBGaramond.zip |
+| Releases | https://bitbucket.org/georgd/eb-garamond/downloads/ |
 
 For more infos please visit http://www.georgduffner.at/ebgaramond/


### PR DESCRIPTION
You'd first need to create a tag "nightly" and an associated pre-release. Then the CI will automatically update the tag and upload the EBGaramond.zip. This way, we have a stable link that can be used in the README.

Since there's no such release in your repository right now, the PR's CI run fails. In my fork, it works as expected:

https://github.com/Alexander-Wilms/EB-Garamond/actions

https://github.com/Alexander-Wilms/EB-Garamond/releases/tag/nightly

![image](https://user-images.githubusercontent.com/3226457/224581495-a5b004ac-1342-4a81-a1cf-9eef391c647f.png)
