### PR TITLE
Make CI builds more easily accessible

### DIFF
--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -4,7 +4,7 @@ on:
   - pull_request
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   linux-build:
@@ -22,12 +22,23 @@ jobs:
       run: sudo apt-get install python3-fontforge ttfautohint
 
     - name: Build
-      run: make -j$(nproc)
+      run: |
+          make -j$(nproc)
+          cd build
+          zip ../EBGaramond.zip *
 
     - name: Upload to Github Artifacts
       if: github.event_name == 'push'
       uses: actions/upload-artifact@v3
       with:
         name: EBGaramond
-        path: build/EBGaramond*
+        path: build/
 
+    - name: Update nightly release
+      if: success()
+      uses: pyTooling/Actions/releaser@main
+      with:
+        tag: nightly
+        rm: true
+        token: ${{ secrets.GITHUB_TOKEN }}
+        files: EBGaramond.zip

--- a/README.md
+++ b/README.md
@@ -9,28 +9,29 @@ For the use with Xe- and LuaLaTeX I’m working on a configuration for mycrotype
 
 ## Fonts in this repository:
 
-- EBGaramond12-Regular: Regular font for design size 12pt
-- EBGaramond12-Italic: Italic font for design size 12pt
-- EBGaramond12-Bold: Bold font for design size 12pt (very rough/unusable; not included in releases)
-- EBGaramond08-Regular: Regular font for design size 8pt
-- EBGaramond08-Italic: Italic font for design size 8pt (very rough spacing!)
-- EBGaramond12-SC: Smallcaps font for programs that ignore opentype features (12pt)
-- EBGaramond12-AllSC: All smallcaps font for programs that ignore opentype features
-- EBGaramond08-SC: Smallcaps font for programs that ignore opentype features (8pt)
-- EBGaramond-Initials: Initials
-- EBGaramond-InitialsF1: Background (the ornament) of initials
-- EBGaramond-InitialsF2: Foreground (the letter) of initials
-- EBGaramond-Lettrines: Workbench for Initials fonts (not included in releases)
+| Font | Description |
+|------|-------------|
+| EBGaramond-Initials | Initials
+| EBGaramond-InitialsF1 | Background (the ornament) of initials
+| EBGaramond-InitialsF2 | Foreground (the letter) of initials
+| EBGaramond-Lettrines | Workbench for Initials fonts (not included in releases)
+| EBGaramond08-Italic | Italic font for design size 8pt (very rough spacing!)
+| EBGaramond08-Regular | Regular font for design size 8pt
+| EBGaramond12-AllSC | All smallcaps font for programs that ignore opentype features
+| EBGaramond12-Italic | Italic font for design size 12pt
+| EBGaramond12-Regular | Regular font for design size 12pt
+| EBGaramond12-Bold | Bold font for design size 12pt (very rough/unusable; not included in releases)
+| EBGaramondSC08-Regular | Smallcaps font for programs that ignore opentype features (12pt)
+| EBGaramondSC08-Regular | Smallcaps font for programs that ignore opentype features (12pt)
+
 
 This is a work in progress, so expect bugs! The quality of the fonts still varies widely! You can see every font’s current state in its *-Glyphs.pdf file in the specimen section.
 
-## Mirrors:
+## Downloads:
 
-Due to Github deciding not to provide a download area any more, this project resides in two mirrored repositories on Github (https://github.com/georgd/EB-Garamond) and Bitbucket (https://bitbucket.org/georgd/eb-garamond). 
-
-- Downloadable zip-files are at https://bitbucket.org/georgd/eb-garamond/downloads
-- The issue tracker continues to live at https://github.com/georgd/EB-Garamond/issues
-- Forks and pull requests should be possible on both platforms
-
+| Type | URL |
+|------|-----|
+| Nightly build | https://github.com/georgd/EB-Garamond/releases/download/nightly/EBGaramond.zip |
+| Releases | https://bitbucket.org/georgd/eb-garamond/downloads/ |
 
 For more infos please visit http://www.georgduffner.at/ebgaramond/


### PR DESCRIPTION
Now it works properly:

https://github.com/Alexander-Wilms/EB-Garamond/actions/runs/4420584427
https://github.com/Alexander-Wilms/EB-Garamond/releases/tag/nightly

The CI in this PR still fails, since it can't overwrite the assets of the `nightly` tag in your repo as long as it's not merged:

```
 · RM set. All previous assets are being cleared...
HTTP 403: Resource not accessible by integration (https://uploads.github.com/repos/georgd/EB-Garamond/releases/95333622/assets?label=&name=EBGaramond.zip)
Traceback (most recent call last):
· Upload assets
 > gh release upload --repo georgd/EB-Garamond --clobber nightly EBGaramond.zip
  File "/releaser.py", line 188, in <module>
    check_call(cmd, env=env)
  File "/usr/local/lib/python3.9/subprocess.py", line 373, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['gh', 'release', 'upload', '--repo', 'georgd/EB-Garamond', '--clobber', 'nightly', 'EBGaramond.zip']' returned non-zero exit status 1.
```